### PR TITLE
Shorten plugin name to 'wrangler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<img src="https://github.com/gabrieljackson/mattermost-plugin-messagewrangler/blob/master/assets/profile.png?raw=true" width="75" height="75" alt="wrangler">
+<img src="https://github.com/gabrieljackson/mattermost-plugin-wrangler/blob/master/assets/profile.png?raw=true" width="75" height="75" alt="wrangler">
 
-# Message Wrangler
+# Mattermost Wrangler Plugin
 
 A [Mattermost](https://mattermost.com) plugin for managing messages.
 
-[![CircleCI](https://circleci.com/gh/gabrieljackson/mattermost-plugin-messagewrangler.svg?style=shield)](https://circleci.com/gh/gabrieljackson/mattermost-plugin-messagewrangler)
+[![CircleCI](https://circleci.com/gh/gabrieljackson/mattermost-plugin-wrangler.svg?style=shield)](https://circleci.com/gh/gabrieljackson/mattermost-plugin-wrangler)
 
 ## Install
 
@@ -15,4 +15,4 @@ A [Mattermost](https://mattermost.com) plugin for managing messages.
 
 ## Usage
 
-Type `/mw` for a list of all Message Wrangler commands.
+Type `/wrangler` for a list of all Wrangler commands.

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
-    "id": "com.mattermost.messagewrangler",
-    "name": "Message Wrangler",
+    "id": "com.mattermost.wrangler",
+    "name": "Wrangler",
     "description": "Manage messages accross teams and channels",
     "version": "0.1.0",
     "min_server_version": "5.12.0",
@@ -19,7 +19,7 @@
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",
-                "help_text": "(Optional) When set, users must have an email ending in this domain to use the message wrangler slash command."
+                "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command."
             },
             {
                 "key": "MaxThreadCountMoveSize",

--- a/server/bot.go
+++ b/server/bot.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-// PostBotDM posts a DM as the Message Wrangler bot user.
+// PostBotDM posts a DM as the Wrangler bot user.
 func (p *Plugin) PostBotDM(userID, message string) error {
 	channel, appError := p.API.GetDirectChannel(userID, p.BotUserID)
 	if appError != nil {

--- a/server/command.go
+++ b/server/command.go
@@ -8,12 +8,12 @@ import (
 	"github.com/mattermost/mattermost-server/plugin"
 )
 
-const helpText = `**Message Wrangler Plugin - Slash Command Help**
+const helpText = `**Wrangler Plugin - Slash Command Help**
 
-* |/mw move thread [POST_ID] [CHANNEL_ID]| - Move a given post, along with the thread it belongs to, to a given channel
+* |/wrangler move thread [POST_ID] [CHANNEL_ID]| - Move a given post, along with the thread it belongs to, to a given channel
   * This can be on any channel in any team that you have joined
-* |/mw list| - List the IDs of all channels you have joined
-* |/mw info| - Shows plugin information`
+* |/wrangler list| - List the IDs of all channels you have joined
+* |/wrangler info| - Shows plugin information`
 
 func getHelp() string {
 	return strings.Replace(helpText, "|", "`", -1)
@@ -21,9 +21,9 @@ func getHelp() string {
 
 func getCommand() *model.Command {
 	return &model.Command{
-		Trigger:          "mw",
-		DisplayName:      "Message Wrangler",
-		Description:      "Move some messages!",
+		Trigger:          "wrangler",
+		DisplayName:      "Wrangler",
+		Description:      "Manage Mattermost messages!",
 		AutoComplete:     false,
 		AutoCompleteDesc: "Available commands: move, list, info",
 		AutoCompleteHint: "[command]",
@@ -34,7 +34,7 @@ func getCommandResponse(responseType, text string) *model.CommandResponse {
 	return &model.CommandResponse{
 		ResponseType: responseType,
 		Text:         text,
-		Username:     "message.wrangler",
+		Username:     "wrangler",
 		IconURL:      fmt.Sprintf("/plugins/%s/profile.png", manifest.ID),
 	}
 }
@@ -92,7 +92,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	if err != nil {
 		p.API.LogError(err.Error())
 		if userError {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("__Error: %s__\n\nRun `/mw help` for usage instructions.", err.Error())), nil
+			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("__Error: %s__\n\nRun `/wrangler help` for usage instructions.", err.Error())), nil
 		}
 
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "An unknown error occurred. Please talk to your administrator for help."), nil
@@ -102,8 +102,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) runInfoCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
-	resp := fmt.Sprintf("Message Wrangler plugin version: %s, "+
-		"[%s](https://github.com/gabrieljackson/mattermost-plugin-messagewrangler/commit/%s), built %s\n\n",
+	resp := fmt.Sprintf("Wrangler plugin version: %s, "+
+		"[%s](https://github.com/gabrieljackson/mattermost-plugin-wrangler/commit/%s), built %s\n\n",
 		manifest.Version, BuildHashShort, BuildHash, BuildDate)
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, resp), false, nil

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -10,10 +10,10 @@ import (
 
 const moveThreadMessage = `Error: missing arguments
 
-Usage: |/mw move thread [POST_ID] [CHANNEL_ID]|
+Usage: |/wrangler move thread [POST_ID] [CHANNEL_ID]|
 
  - Obtain the post ID via the |Permalink| post dropdown option. It's the last part of the URL.
- - Obtain the channel ID via the Channel |View Info| option or by running |/mw list|.
+ - Obtain the channel ID via the Channel |View Info| option or by running |/wrangler list|.
 `
 
 func getMoveThreadMessage() string {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -4,6 +4,6 @@ var manifest = struct {
 	ID      string
 	Version string
 }{
-	ID:      "com.mattermost.messagewrangler",
+	ID:      "com.mattermost.wrangler",
 	Version: "0.1.0",
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -44,12 +44,12 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	botID, err := p.Helpers.EnsureBot(&model.Bot{
-		Username:    "message.wrangler",
-		DisplayName: "Message Wrangler",
-		Description: "Created by the Message Wrangler plugin.",
+		Username:    "wrangler",
+		DisplayName: "Wrangler",
+		Description: "Created by the Wrangler plugin.",
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to ensure Message Wrangler bot")
+		return errors.Wrap(err, "failed to ensure Wrangler bot")
 	}
 	p.BotUserID = botID
 


### PR DESCRIPTION
This was done to accommodate the possibility of the plugin being
able to manage more than just messages in the future. Also, shorter
names are usually better.

The plugin command is also now standardized to `/wrangler`.