### PR TITLE
Improve move-thread bot message

### DIFF
--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -119,7 +119,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		}
 	}
 
-	msg := fmt.Sprintf("A thread with %d posts has been moved to %s:%s", len(finalList), targetTeam.Name, targetChannel.Name)
+	msg := fmt.Sprintf("A thread with %d posts has been moved [ team=%s, channel=%s ]", len(finalList), targetTeam.Name, targetChannel.Name)
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, msg), false, nil
 }

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -55,7 +55,7 @@ func TestMoveThreadCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2"}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, fmt.Sprintf("A thread with %d posts has been moved to %s:%s", 3, targetTeam.Name, targetChannel.Name))
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread with %d posts has been moved [ team=%s, channel=%s ]", 3, targetTeam.Name, targetChannel.Name))
 	})
 
 	t.Run("not in thread channel", func(t *testing.T) {


### PR DESCRIPTION
This provides better clarity on where the moved thread ended up.