### PR TITLE
Add count flag to list messages command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/mattermost/mattermost-server/v5 v5.19.1
 	github.com/pkg/errors v0.8.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,7 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=

--- a/server/command.go
+++ b/server/command.go
@@ -8,18 +8,26 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
-const helpText = `**Wrangler Plugin - Slash Command Help**
+const helpText = `Wrangler Plugin - Slash Command Help
 
-* |/wrangler move thread [MESSAGE_ID] [CHANNEL_ID]| - Move a given message, along with the thread it belongs to, to a given channel
-  * This can be on any channel in any team that you have joined
-  * Obtain the message ID by running |/wrangler list messages| or via the |Permalink| message dropdown option (it's the last part of the URL)
-  * Obtain the channel ID by running |/wrangler list channels| or via the channel |View Info| option
-* |/wrangler list channels| - List the IDs of all channels you have joined
-* |/wrangler list messages| - List the IDs of the 20 most recent messages in this channel
-* |/wrangler info| - Shows plugin information`
+- /wrangler move thread [MESSAGE_ID] [CHANNEL_ID]
+    Move a given message, along with the thread it belongs to, to a given channel
+    - This can be on any channel in any team that you have joined
+    - Obtain the message ID by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
+    - Obtain the channel ID by running '/wrangler list channels' or via the channel 'View Info' option
+
+- /wrangler list channels
+    List the IDs of all channels you have joined
+
+- /wrangler list messages [flags]
+    List the IDs of recent messages in this channel
+    Flags:
+%s
+- /wrangler info
+    Shows plugin information`
 
 func getHelp() string {
-	return strings.Replace(helpText, "|", "`", -1)
+	return codeBlock(fmt.Sprintf(helpText, getListMessagesFlagSet().FlagUsages()))
 }
 
 func getCommand() *model.Command {

--- a/server/command_message_list.go
+++ b/server/command_message_list.go
@@ -5,17 +5,57 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/spf13/pflag"
 )
 
-func (p *Plugin) runListMessagesCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
-	var msg string
+const (
+	minListMessagesCount = 1
+	maxListMessagesCount = 100
+)
 
-	channelPosts, appErr := p.API.GetPostsForChannel(extra.ChannelId, 0, 20)
+type listOptions struct {
+	count int
+}
+
+func getListMessagesFlagSet() *pflag.FlagSet {
+	listMessagesFlagSet := pflag.NewFlagSet("list messages", pflag.ContinueOnError)
+	listMessagesFlagSet.Int("count", 20, fmt.Sprintf("Number of messages to return. Must be between %d and %d", minListMessagesCount, maxListMessagesCount))
+
+	return listMessagesFlagSet
+}
+
+func parseListMessagesArgs(args []string) (listOptions, error) {
+	var options listOptions
+
+	listMessagesFlagSet := getListMessagesFlagSet()
+	err := listMessagesFlagSet.Parse(args)
+	if err != nil {
+		return options, err
+	}
+
+	options.count, err = listMessagesFlagSet.GetInt("count")
+	if err != nil {
+		return options, err
+	}
+	if options.count < minListMessagesCount || options.count > maxListMessagesCount {
+		return options, fmt.Errorf("count (%d) must be between %d and %d", options.count, minListMessagesCount, maxListMessagesCount)
+	}
+
+	return options, err
+}
+
+func (p *Plugin) runListMessagesCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	options, err := parseListMessagesArgs(args)
+	if err != nil {
+		return nil, true, err
+	}
+
+	channelPosts, appErr := p.API.GetPostsForChannel(extra.ChannelId, 0, options.count)
 	if appErr != nil {
 		return nil, false, appErr
 	}
 
-	msg += "The last 20 messages in this channel:\n"
+	msg := fmt.Sprintf("The last %d messages in this channel:\n", options.count)
 	for _, post := range channelPosts.ToSlice() {
 		if post.IsSystemMessage() {
 			msg += "[     system message     ] - <skipped>\n"

--- a/server/command_message_list_test.go
+++ b/server/command_message_list_test.go
@@ -16,7 +16,7 @@ func TestMessagelListCommand(t *testing.T) {
 		Name: "test-channel",
 	}
 
-	testPostList := mockGeneratePostList(3, testChannel.Id)
+	testPostList := mockGeneratePostList(3, testChannel.Id, false)
 
 	api := &plugintest.API{}
 	api.On("GetPostsForChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(testPostList, nil)
@@ -24,7 +24,7 @@ func TestMessagelListCommand(t *testing.T) {
 	var plugin Plugin
 	plugin.SetAPI(api)
 
-	t.Run("list channels successfully", func(t *testing.T) {
+	t.Run("list messages successfully", func(t *testing.T) {
 		resp, isUserError, err := plugin.runListMessagesCommand([]string{}, &model.CommandArgs{ChannelId: testChannel.Id})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
@@ -32,6 +32,47 @@ func TestMessagelListCommand(t *testing.T) {
 			assert.Contains(t, resp.Text, post.Id)
 			assert.Contains(t, resp.Text, post.Message)
 		}
+	})
+
+	t.Run("specify valid count", func(t *testing.T) {
+		resp, isUserError, err := plugin.runListMessagesCommand([]string{"--count=50"}, &model.CommandArgs{ChannelId: testChannel.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "The last 50 messages in this channel")
+		for _, post := range testPostList.ToSlice() {
+			assert.Contains(t, resp.Text, post.Id)
+			assert.Contains(t, resp.Text, post.Message)
+			assert.Contains(t, resp.Text, post.Message)
+		}
+	})
+
+	t.Run("specify count that is too low", func(t *testing.T) {
+		_, isUserError, err := plugin.runListMessagesCommand([]string{"--count=-1"}, &model.CommandArgs{ChannelId: testChannel.Id})
+		require.Error(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, err.Error(), "count (-1) must be between 1 and 100")
+	})
+
+	t.Run("specify count that is too high", func(t *testing.T) {
+		_, isUserError, err := plugin.runListMessagesCommand([]string{"--count=120"}, &model.CommandArgs{ChannelId: testChannel.Id})
+		require.Error(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, err.Error(), "count (120) must be between 1 and 100")
+	})
+
+	t.Run("list messages successfully with system", func(t *testing.T) {
+		testPostList := mockGeneratePostList(3, testChannel.Id, true)
+
+		api := &plugintest.API{}
+		api.On("GetPostsForChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(testPostList, nil)
+
+		var plugin Plugin
+		plugin.SetAPI(api)
+
+		resp, isUserError, err := plugin.runListMessagesCommand([]string{}, &model.CommandArgs{ChannelId: testChannel.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "[     system message     ] - <skipped>")
 	})
 }
 

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
@@ -10,14 +9,15 @@ import (
 
 const moveThreadMessage = `Error: missing arguments
 
-Usage: |/wrangler move thread [MESSAGE_ID] [CHANNEL_ID]|
-
- * Obtain the message ID via the |Permalink| message dropdown option. It's the last part of the URL.
- * Obtain the channel ID via the Channel |View Info| option or by running |/wrangler list|.
+- /wrangler move thread [MESSAGE_ID] [CHANNEL_ID]
+    Move a given message, along with the thread it belongs to, to a given channel
+    - This can be on any channel in any team that you have joined
+    - Obtain the message ID by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
+    - Obtain the channel ID by running '/wrangler list channels' or via the channel 'View Info' option
 `
 
 func getMoveThreadMessage() string {
-	return strings.Replace(moveThreadMessage, "|", "`", -1)
+	return codeBlock(moveThreadMessage)
 }
 
 func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -27,7 +27,7 @@ func TestMoveThreadCommand(t *testing.T) {
 	}
 
 	api := &plugintest.API{}
-	api.On("GetPostThread", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(mockGeneratePostList(3, originalChannel.Id), nil)
+	api.On("GetPostThread", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(mockGeneratePostList(3, originalChannel.Id, false), nil)
 	api.On("GetChannelMember", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(mockGenerateChannelMember(), nil)
 	api.On("GetChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(targetChannel, nil)
 	api.On("GetTeam", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(targetTeam, nil)
@@ -75,15 +75,19 @@ func TestMoveThreadCommand(t *testing.T) {
 	})
 }
 
-func mockGeneratePostList(total int, channelID string) *model.PostList {
+func mockGeneratePostList(total int, channelID string, systemMessages bool) *model.PostList {
 	postList := model.NewPostList()
 	for i := 0; i < total; i++ {
 		id := model.NewId()
-		postList.AddPost(&model.Post{
+		post := &model.Post{
 			Id:        id,
 			ChannelId: channelID,
 			Message:   fmt.Sprintf("This is message %d", i),
-		})
+		}
+		if systemMessages {
+			post.Type = model.POST_SYSTEM_MESSAGE_PREFIX
+		}
+		postList.AddPost(post)
 		postList.AddOrder(id)
 	}
 


### PR DESCRIPTION
This adds a flag to allow for the 'list messages' command to return
more or less messages in a channel.

Along with increased testing for this new feature, the help text
for the slash commands was improved to return the new flag option.