### PR TITLE
Add private channel move configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ The following plugin configuration is available:
 
  - Allowed Email Domain: an optional setting to limit plugin usage to specific users
  - Max Thread Count Move Size: an optional setting to limit the size of threads that can be moved
+ - Enable Moving Threads From Private Channels: Control whether Wrangler is permitted to move message threads from private channels or not

--- a/plugin.json
+++ b/plugin.json
@@ -26,6 +26,13 @@
                 "display_name": "Max Thread Count Move Size",
                 "type": "text",
                 "help_text": "The maximum number of messages in a thread that is allowed to be moved by the plugin. Leave empty for unlimited messages."
+            },
+            {
+                "key": "MoveThreadFromPrivateChannelEnable",
+                "display_name": "Enable Moving Threads From Private Channels",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to move message threads from private channels or not",
+                "default": true
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -21,8 +21,9 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	AllowedEmailDomain     string
-	MaxThreadCountMoveSize string
+	AllowedEmailDomain                 string
+	MaxThreadCountMoveSize             string
+	MoveThreadFromPrivateChannelEnable bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if


### PR DESCRIPTION
This change adds a configuration option to prevent threads from
being moved if they belong to a private channel.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/17