### PR TITLE
Add direct message channel move configuration

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -33,6 +33,13 @@
                 "type": "bool",
                 "help_text": "Control whether Wrangler is permitted to move message threads from private channels or not",
                 "default": true
+            },
+            {
+                "key": "MoveThreadFromDirectMessageChannelEnable",
+                "display_name": "Enable Moving Threads From Direct Message Channels",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to move message threads from direct message channels or not",
+                "default": false
             }
         ]
     }

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -38,6 +38,10 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		if !config.MoveThreadFromPrivateChannelEnable {
 			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Wrangler is currently configured to not allow moving posts from private channels"), false, nil
 		}
+	case model.CHANNEL_DIRECT:
+		if !config.MoveThreadFromDirectMessageChannelEnable {
+			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Wrangler is currently configured to not allow moving posts from direct message channels"), false, nil
+		}
 	}
 
 	postListResponse, appErr := p.API.GetPostThread(postID)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -21,9 +21,10 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	AllowedEmailDomain                 string
-	MaxThreadCountMoveSize             string
-	MoveThreadFromPrivateChannelEnable bool
+	AllowedEmailDomain                       string
+	MaxThreadCountMoveSize                   string
+	MoveThreadFromPrivateChannelEnable       bool
+	MoveThreadFromDirectMessageChannelEnable bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if


### PR DESCRIPTION
This change adds a configuration option to prevent threads from
being moved if they belong to a direct message channel.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/18