### PR TITLE
Add group message channel move configuration

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -40,6 +40,13 @@
                 "type": "bool",
                 "help_text": "Control whether Wrangler is permitted to move message threads from direct message channels or not",
                 "default": false
+            },
+            {
+                "key": "MoveThreadFromGroupMessageChannelEnable",
+                "display_name": "Enable Moving Threads From Group Message Channels",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to move message threads from group message channels or not",
+                "default": false
             }
         ]
     }

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -42,6 +42,10 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		if !config.MoveThreadFromDirectMessageChannelEnable {
 			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Wrangler is currently configured to not allow moving posts from direct message channels"), false, nil
 		}
+	case model.CHANNEL_GROUP:
+		if !config.MoveThreadFromGroupMessageChannelEnable {
+			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Wrangler is currently configured to not allow moving posts from group message channels"), false, nil
+		}
 	}
 
 	postListResponse, appErr := p.API.GetPostThread(postID)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -25,6 +25,7 @@ type configuration struct {
 	MaxThreadCountMoveSize                   string
 	MoveThreadFromPrivateChannelEnable       bool
 	MoveThreadFromDirectMessageChannelEnable bool
+	MoveThreadFromGroupMessageChannelEnable  bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if


### PR DESCRIPTION
This change adds a configuration option to prevent threads from
being moved if they belong to a group message channel.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/19