### PR TITLE
Clean message content before presenting list

### DIFF
--- a/server/command_list_messages.go
+++ b/server/command_list_messages.go
@@ -75,13 +75,24 @@ func (p *Plugin) runListMessagesCommand(args []string, extra *model.CommandArgs)
 		if post.IsSystemMessage() {
 			msg += "[     system message     ] - <skipped>\n"
 		} else {
-			msg += fmt.Sprintf("%s - %s\n", post.Id, trimMessage(post.Message, options.trimLength))
+			msg += fmt.Sprintf("%s - %s\n", post.Id, cleanAndTrimMessage(post.Message, options.trimLength))
 		}
 	}
 
 	msg = codeBlock(strings.TrimRight(msg, "\n"))
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg), false, nil
+}
+
+func cleanAndTrimMessage(message string, trimLength int) string {
+	return trimMessage(cleanMessage(message), trimLength)
+}
+
+func cleanMessage(message string) string {
+	message = strings.Replace(message, "```", "", -1)
+	message = strings.Replace(message, "\n", " | ", -1)
+
+	return message
 }
 
 func trimMessage(message string, trimLength int) string {

--- a/server/command_list_messages_test.go
+++ b/server/command_list_messages_test.go
@@ -102,6 +102,38 @@ func TestMessagelListCommand(t *testing.T) {
 	})
 }
 
+func TestCleanMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "no cleanup needed",
+			message: "short",
+		},
+		{
+			name:    "remove codeblock",
+			message: "```code goes here```",
+		},
+		{
+			name:    "remove newlines",
+			message: "this message \n has multiple \n newlines \n probably",
+		},
+		{
+			name:    "remove codeblock and newlines",
+			message: "this `` ` ```message \n has` ``` multiple \n newlines \n probably ` ````",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanedMessage := cleanMessage(tt.message)
+			assert.NotContains(t, cleanedMessage, "```")
+			assert.NotContains(t, cleanedMessage, "\n")
+		})
+	}
+}
+
 func TestTrimMessage(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Certain substrings are now removed or altered before showing the
results of the 'list message' command. This is done to prevent
the message content from breaking the list formatting.

https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/24