### PR TITLE
Rename max thread count config key

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -22,10 +22,10 @@
                 "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command."
             },
             {
-                "key": "MaxThreadCountMoveSize",
+                "key": "MoveThreadMaxCount",
                 "display_name": "Max Thread Count Move Size",
                 "type": "text",
-                "help_text": "The maximum number of messages in a thread that is allowed to be moved by the plugin. Leave empty for unlimited messages."
+                "help_text": "The maximum number of messages in a thread that the plugin is allowed to move. Leave empty for unlimited messages."
             },
             {
                 "key": "MoveThreadFromPrivateChannelEnable",

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -123,7 +123,7 @@ func TestMoveThreadCommand(t *testing.T) {
 	})
 
 	t.Run("thread is above configuration move-maximum", func(t *testing.T) {
-		plugin.setConfiguration(&configuration{MaxThreadCountMoveSize: "1"})
+		plugin.setConfiguration(&configuration{MoveThreadMaxCount: "1"})
 		require.NoError(t, plugin.configuration.IsValid())
 		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2"}, &model.CommandArgs{ChannelId: model.NewId()})
 		require.NoError(t, err)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -21,8 +21,9 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	AllowedEmailDomain                       string
-	MaxThreadCountMoveSize                   string
+	AllowedEmailDomain string
+
+	MoveThreadMaxCount                       string
 	MoveThreadFromPrivateChannelEnable       bool
 	MoveThreadFromDirectMessageChannelEnable bool
 	MoveThreadFromGroupMessageChannelEnable  bool
@@ -41,9 +42,9 @@ func (c *configuration) IsValid() error {
 		return errors.Wrap(err, "invalid AllowedEmailDomain")
 	}
 
-	_, err = parseAndValidateMaxThreadCountMoveSize(c.MaxThreadCountMoveSize)
+	_, err = parseAndValidateMaxThreadCountMoveSize(c.MoveThreadMaxCount)
 	if err != nil {
-		return errors.Wrap(err, "invalid MaxThreadCountMoveSize")
+		return errors.Wrap(err, "invalid MoveThreadMaxSize")
 	}
 
 	return nil
@@ -51,7 +52,7 @@ func (c *configuration) IsValid() error {
 
 func (c *configuration) MaxThreadCountMoveSizeInt() int {
 	// Use the parseAndValidate function, but ignore the error.
-	i, _ := parseAndValidateMaxThreadCountMoveSize(c.MaxThreadCountMoveSize)
+	i, _ := parseAndValidateMaxThreadCountMoveSize(c.MoveThreadMaxCount)
 
 	return i
 }
@@ -67,10 +68,10 @@ func parseAndValidateMaxThreadCountMoveSize(s string) (int, error) {
 
 	max, err := strconv.Atoi(s)
 	if err != nil {
-		return 0, errors.Wrapf(err, "MaxThreadCountMoveSize value %s is not a valid integer", s)
+		return 0, errors.Wrapf(err, "MoveThreadMaxSize value %s is not a valid integer", s)
 	}
 	if max < 1 {
-		return 0, fmt.Errorf("MaxThreadCountMoveSize (%d) must be greater than 0", max)
+		return 0, fmt.Errorf("MoveThreadMaxSize (%d) must be greater than 0", max)
 	}
 
 	return max, nil

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestConfigurationIsValid(t *testing.T) {
 	baseConfiguration := configuration{
-		AllowedEmailDomain:     "mattermost.com",
-		MaxThreadCountMoveSize: "10",
+		AllowedEmailDomain: "mattermost.com",
+		MoveThreadMaxCount: "10",
 	}
 
 	t.Run("valid", func(t *testing.T) {
@@ -20,12 +20,12 @@ func TestConfigurationIsValid(t *testing.T) {
 		config := baseConfiguration
 
 		t.Run("invalid integer", func(t *testing.T) {
-			config.MaxThreadCountMoveSize = "twenty"
+			config.MoveThreadMaxCount = "twenty"
 			require.Error(t, config.IsValid())
 		})
 
 		t.Run("negative integer", func(t *testing.T) {
-			config.MaxThreadCountMoveSize = "-10"
+			config.MoveThreadMaxCount = "-10"
 			err := config.IsValid()
 			if err == nil {
 				t.Log("WTF")
@@ -35,7 +35,7 @@ func TestConfigurationIsValid(t *testing.T) {
 		})
 
 		t.Run("unset value", func(t *testing.T) {
-			config.MaxThreadCountMoveSize = ""
+			config.MoveThreadMaxCount = ""
 			require.NoError(t, config.IsValid())
 		})
 	})


### PR DESCRIPTION
The new name should provide a clearer understanding of the purpose
of the setting.

This setting will need to be reentered if it was previously changed
from the default.