### PR TITLE
Add configuration for moving threads between teams

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,6 +28,13 @@
                 "help_text": "The maximum number of messages in a thread that the plugin is allowed to move. Leave empty for unlimited messages."
             },
             {
+                "key": "MoveThreadToAnotherTeamEnable",
+                "display_name": "Enable Moving Threads To Different Teams",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to move message threads from one team to another",
+                "default": false
+            },
+            {
                 "key": "MoveThreadFromPrivateChannelEnable",
                 "display_name": "Enable Moving Threads From Private Channels",
                 "type": "bool",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -24,6 +24,7 @@ type configuration struct {
 	AllowedEmailDomain string
 
 	MoveThreadMaxCount                       string
+	MoveThreadToAnotherTeamEnable            bool
 	MoveThreadFromPrivateChannelEnable       bool
 	MoveThreadFromDirectMessageChannelEnable bool
 	MoveThreadFromGroupMessageChannelEnable  bool


### PR DESCRIPTION
This change adds a configuration option to prevent threads from
being moved to different teams.