### PR TITLE
Add 'attach message' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Wrangler Plugin - Slash Command Help
     - Obtain the message ID by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
     - Obtain the channel ID by running '/wrangler list channels' or via the channel 'View Info' option
 
+/wrangler attach message [MESSAGE_ID_TO_BE_ATTACHED] [ROOT_MESSAGE_ID]
+  Attach a given message to a thread in the same channel
+    - Obtain the message IDs by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
+
 /wrangler list channels [flags]
   List the IDs of all channels you have joined
     Flags:
@@ -66,6 +70,12 @@ A thread that was started in `channel1` is moved to `channel2`.
 The thread after being "moved" to `channel2`.
 
 ![channel2](https://user-images.githubusercontent.com/3694686/73672959-d499ea80-467b-11ea-97dc-4a2e33c8829e.png)
+
+#### /wrangler attach message
+
+Attaches a message that is not currently in a thread to an existing message or thread in the same channel.
+
+This is useful for bringing normal messages about a topic into threads that they relate to.
 
 #### /wrangler list channels
 

--- a/server/command.go
+++ b/server/command.go
@@ -16,6 +16,10 @@ const helpText = `Wrangler Plugin - Slash Command Help
     - Obtain the message ID by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
     - Obtain the channel ID by running '/wrangler list channels' or via the channel 'View Info' option
 
+/wrangler attach message [MESSAGE_ID_TO_BE_ATTACHED] [ROOT_MESSAGE_ID]
+  Attach a given message to a thread in the same channel
+    - Obtain the message IDs by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
+
 /wrangler list channels [flags]
   List the IDs of all channels you have joined
 	Flags:
@@ -89,6 +93,16 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		switch stringArgs[2] {
 		case "thread":
 			handler = p.runMoveThreadCommand
+			stringArgs = stringArgs[3:]
+		}
+	case "attach":
+		if len(stringArgs) < 3 {
+			break
+		}
+
+		switch stringArgs[2] {
+		case "message":
+			handler = p.runAttachMessageCommand
 			stringArgs = stringArgs[3:]
 		}
 	case "list":

--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
+)
+
+const attachMessageCommand = `Error: missing arguments
+
+/wrangler attach message [MESSAGE_ID_TO_BE_ATTACHED] [ROOT_MESSAGE_ID]
+	Attach a given message to a thread in the same channel
+	  - Obtain the message IDs by running '/wrangler list messages' or via the 'Permalink' message dropdown option (it's the last part of the URL)
+`
+
+func getAttachMessageCommand() string {
+	return codeBlock(attachMessageCommand)
+}
+
+func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if len(args) < 2 {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getAttachMessageCommand()), true, nil
+	}
+	postToBeAttachedID := args[0]
+	postToAttachToID := args[1]
+
+	postToBeAttached, appErr := p.API.GetPost(postToBeAttachedID)
+	if appErr != nil {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: unable to get message with ID %s; ensure this is correct", postToBeAttachedID)), true, nil
+	}
+	postToAttachTo, appErr := p.API.GetPost(postToAttachToID)
+	if appErr != nil {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: unable to get message with ID %s; ensure this is correct", postToAttachToID)), true, nil
+	}
+
+	if postToBeAttached.ChannelId != extra.ChannelId {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the attach command must be run from the channel containing the messages"), true, nil
+	}
+	if postToAttachTo.ChannelId != extra.ChannelId {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: unable to attach message to a thread in another channel"), true, nil
+	}
+	if len(postToBeAttached.RootId) != 0 || len(postToBeAttached.ParentId) != 0 {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the message to be attached is already part of a thread"), true, nil
+	}
+
+	// We now know:
+	// 1. The post IDs are valid.
+	// 2. The post to be attached is not part of a thread already.
+	// 3. The posts are in the same channel.
+	// 4. The command was run from the original channel with the posts, so they
+	//    are also a member of that channel.
+
+	newRootID := postToAttachTo.Id
+	if len(postToAttachTo.RootId) != 0 {
+		newRootID = postToAttachTo.RootId
+	}
+	cleanupID := postToBeAttached.Id
+
+	// Begin attaching message to the thread.
+	p.API.LogInfo("Wrangler is attaching a message",
+		"user_id", extra.UserId,
+		"post_to_be_attached", postToBeAttachedID,
+		"new_root_id", newRootID,
+	)
+
+	cleanPost(postToBeAttached)
+	postToBeAttached.RootId = newRootID
+	postToBeAttached.ParentId = newRootID
+
+	_, appErr = p.API.CreatePost(postToBeAttached)
+	if appErr != nil {
+		return nil, false, errors.Wrap(appErr, "unable to create new post")
+	}
+
+	appErr = p.API.DeletePost(cleanupID)
+	if appErr != nil {
+		return nil, false, errors.Wrap(appErr, "unable to delete post")
+	}
+
+	p.API.LogInfo("Wrangler has attached a message",
+		"user_id", extra.UserId,
+		"post_to_be_attached", postToBeAttachedID,
+		"new_root_id", newRootID,
+	)
+
+	msg := fmt.Sprintf("Message successfully attached to thread")
+
+	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, msg), false, nil
+}

--- a/server/command_attach_message_test.go
+++ b/server/command_attach_message_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachMessageCommand(t *testing.T) {
+	team1 := &model.Team{
+		Id:   model.NewId(),
+		Name: "team-1",
+	}
+	channel1 := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "channel1",
+		Type:   model.CHANNEL_OPEN,
+	}
+	postToBeAttached := &model.Post{
+		Id:        model.NewId(),
+		ChannelId: channel1.Id,
+	}
+	postToAttachTo := &model.Post{
+		Id:        model.NewId(),
+		ChannelId: channel1.Id,
+	}
+	rootID := model.NewId()
+	postInThreadAlready := &model.Post{
+		Id:        model.NewId(),
+		ChannelId: channel1.Id,
+		RootId:    rootID,
+		ParentId:  rootID,
+	}
+
+	postInAnotherChannel := &model.Post{
+		Id:        model.NewId(),
+		ChannelId: model.NewId(),
+	}
+
+	api := &plugintest.API{}
+	api.On("GetPost", postToBeAttached.Id).Return(postToBeAttached, nil)
+	api.On("GetPost", postToAttachTo.Id).Return(postToAttachTo, nil)
+	api.On("GetPost", postInThreadAlready.Id).Return(postInThreadAlready, nil)
+	api.On("GetPost", postInAnotherChannel.Id).Return(postInAnotherChannel, nil)
+	api.On("GetPost", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil, model.NewAppError("where", model.NewId(), nil, "not found", 0))
+	api.On("CreatePost", mock.Anything, mock.Anything).Return(mockGeneratePost(), nil)
+	api.On("DeletePost", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil)
+	api.On("LogInfo",
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+	).Return(nil)
+
+	var plugin Plugin
+	plugin.SetAPI(api)
+
+	t.Run("no args", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{}, &model.CommandArgs{ChannelId: channel1.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: missing arguments")
+	})
+
+	t.Run("one arg", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{"id1"}, &model.CommandArgs{ChannelId: channel1.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: missing arguments")
+	})
+
+	t.Run("post to be attached invalid", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{model.NewId(), postToAttachTo.Id}, &model.CommandArgs{ChannelId: model.NewId()})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: unable to get message with ID")
+	})
+
+	t.Run("post to be attached to invalid", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToBeAttached.Id, model.NewId()}, &model.CommandArgs{ChannelId: model.NewId()})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: unable to get message with ID")
+	})
+
+	t.Run("not in channel with messages", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToBeAttached.Id, postToAttachTo.Id}, &model.CommandArgs{ChannelId: model.NewId()})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: the attach command must be run from the channel containing the messages")
+	})
+
+	t.Run("attach to message in another channel", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToBeAttached.Id, postInAnotherChannel.Id}, &model.CommandArgs{ChannelId: channel1.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: unable to attach message to a thread in another channel")
+	})
+
+	t.Run("attach message already in another thread", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postInThreadAlready.Id, postToAttachTo.Id}, &model.CommandArgs{ChannelId: channel1.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: the message to be attached is already part of a thread")
+	})
+
+	t.Run("attach message successfully", func(t *testing.T) {
+		plugin.setConfiguration(&configuration{MoveThreadToAnotherTeamEnable: true})
+		require.NoError(t, plugin.configuration.IsValid())
+
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToBeAttached.Id, postToAttachTo.Id}, &model.CommandArgs{ChannelId: channel1.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "Message successfully attached to thread")
+	})
+}

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -165,10 +165,3 @@ func sortedPostsFromPostList(postList *model.PostList) []*model.Post {
 
 	return reversedPosts
 }
-
-func cleanPost(post *model.Post) {
-	post.Id = ""
-	post.CreateAt = 0
-	post.UpdateAt = 0
-	post.EditAt = 0
-}

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,7 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
+
+func cleanPost(post *model.Post) {
+	post.Id = ""
+	post.CreateAt = 0
+	post.UpdateAt = 0
+	post.EditAt = 0
+}
 
 func prettyPrintJSON(in string) string {
 	var out bytes.Buffer


### PR DESCRIPTION
This attaches a message that is not currently in a thread to an
existing message or thread in the same channel.

This is useful for bringing normal messages about a topic into
threads that they relate to.