### PR TITLE
Fancier thread move message

### DIFF
--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -113,7 +113,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 			if appErr != nil {
 				return nil, false, errors.Wrap(appErr, "unable to create new root post")
 			}
-			originalMessageSummary = cleanAndTrimMessage(post.Message, 100)
+			originalMessageSummary = cleanAndTrimMessage(post.Message, 500)
 
 			continue
 		}
@@ -150,12 +150,12 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		"new_channel_id", channelID,
 	)
 
-	msg := fmt.Sprintf(
-		"A thread with %d posts has been moved [ team=%s, channel=%s ]\n\nOriginal Message:\n%s",
-		wpl.NumPosts(),
-		targetTeam.Name, targetChannel.Name,
-		quoteBlock(originalMessageSummary),
+	msg := fmt.Sprintf("A thread has been moved: %s\n", makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, newRootPost.Id))
+	msg += fmt.Sprintf(
+		"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
+		targetTeam.Name, targetChannel.Name, wpl.NumPosts(),
 	)
+	msg += fmt.Sprintf("Original Thread Root Message:\n%s\n", quoteBlock(originalMessageSummary))
 
 	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, msg), false, nil
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -9,6 +9,10 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
+func makePostLink(siteURL, postID string) string {
+	return fmt.Sprintf("%s/_redirect/pl/%s", siteURL, postID)
+}
+
 func cleanPost(post *model.Post) {
 	post.Id = ""
 	post.CreateAt = 0


### PR DESCRIPTION
The message posted by Wrangler when a thread is moved is now even
fancier and contains a link to the moved-thread's new root post.