### PR TITLE
Add config option to display wrangler command autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Shows version and commit information for the currently-running plugin build.
 The following plugin configuration is available:
 
  - Allowed Email Domain: an optional setting to limit plugin usage to specific users
+ - Enable Wrangler Command AutoComplete: Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.
  - Max Thread Count Move Size: an optional setting to limit the size of threads that can be moved
  - Enable Moving Threads From Private Channels: Control whether Wrangler is permitted to move message threads from private channels or not
  - Enable Moving Threads From Direct Message Channels: Control whether Wrangler is permitted to move message threads from direct message channels or not

--- a/plugin.json
+++ b/plugin.json
@@ -22,6 +22,13 @@
                 "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command."
             },
             {
+                "key": "CommandAutoCompleteEnable",
+                "display_name": "Enable Wrangler Command AutoComplete",
+                "type": "bool",
+                "help_text": "Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.",
+                "default": false
+            },
+            {
                 "key": "MoveThreadMaxCount",
                 "display_name": "Max Thread Count Move Size",
                 "type": "text",

--- a/server/command.go
+++ b/server/command.go
@@ -39,13 +39,13 @@ func getHelp() string {
 	))
 }
 
-func getCommand() *model.Command {
+func getCommand(autocomplete bool) *model.Command {
 	return &model.Command{
 		Trigger:          "wrangler",
 		DisplayName:      "Wrangler",
 		Description:      "Manage Mattermost messages!",
-		AutoComplete:     false,
-		AutoCompleteDesc: "Available commands: move, list, info",
+		AutoComplete:     autocomplete,
+		AutoCompleteDesc: "Available commands: move thread, attach message, list messages, list channels, info",
 		AutoCompleteHint: "[command]",
 	}
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,6 +23,8 @@ import (
 type configuration struct {
 	AllowedEmailDomain string
 
+	CommandAutoCompleteEnable bool
+
 	MoveThreadMaxCount                       string
 	MoveThreadToAnotherTeamEnable            bool
 	MoveThreadFromPrivateChannelEnable       bool
@@ -130,5 +132,5 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
-	return nil
+	return p.API.RegisterCommand(getCommand(configuration.CommandAutoCompleteEnable))
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -38,6 +38,14 @@ const manifestStr = `
         "default": null
       },
       {
+        "key": "CommandAutoCompleteEnable",
+        "display_name": "Enable Wrangler Command AutoComplete",
+        "type": "bool",
+        "help_text": "Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.",
+        "placeholder": "",
+        "default": false
+      },
+      {
         "key": "MoveThreadMaxCount",
         "display_name": "Max Thread Count Move Size",
         "type": "text",

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -56,5 +56,5 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.BotUserID = botID
 
-	return p.API.RegisterCommand(getCommand())
+	return p.API.RegisterCommand(getCommand(config.CommandAutoCompleteEnable))
 }


### PR DESCRIPTION
Command autocomplete was originally hidden in an attempt to lessen
confusion when `Allowed Email Domain` configuration was set. This
new configuration option allows the plugin administrators to decide
if autocomplete should be shown for the plugin or not.