### PR TITLE
Prevent 'attach message' command from being run inside of thread

### DIFF
--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -43,6 +43,9 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	if len(postToBeAttached.RootId) != 0 || len(postToBeAttached.ParentId) != 0 {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the message to be attached is already part of a thread"), true, nil
 	}
+	if extra.RootId == postToBeAttached.Id || extra.ParentId == postToBeAttached.Id {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the 'attach message' command cannot be run from inside the thread of the message being attached; please run directly in the channel containing the message you wish to attach"), true, nil
+	}
 
 	// We now know:
 	// 1. The post IDs are valid.


### PR DESCRIPTION
Wrangler will now check if the 'attach message' command is being run
from inside the thread of the message to be attached. This is done
to prevent an issue where the command response would attempt to be
posted in the thread that was recently deleted due to the attach.