### PR TITLE
Preserve message timestamp when attaching it to a thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,6 @@ A: That isn't a question, but I hear you. It's actively in the works.
 
 Q: It would be awesome if Wrangler could do this other thing! Is that coming any time soon?
 A: Please open a GitHub issue and I would be happy to see if we can implement it.
+
+Q: When I run `/wranger attach message` it seems like the attached message is out of order?
+A: When attaching a message, it's necessary to create a new post in the thread which triggers the default behavior of Mattermost to show the message at the bottom of the channel. The message has been attached to the thread with the correct timestamp of when it was originally posted though, so simply reloading the channel will resolve the out-of-order behavior you are initially experiencing. This is also something I would like to improve in the future if possible. (Note that this behavior was changed for Wrangler after v0.3.0 was cut)

--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -67,7 +67,7 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 		"new_root_id", newRootID,
 	)
 
-	cleanPost(postToBeAttached)
+	cleanPostID(postToBeAttached)
 	postToBeAttached.RootId = newRootID
 	postToBeAttached.ParentId = newRootID
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -20,6 +20,10 @@ func cleanPost(post *model.Post) {
 	post.EditAt = 0
 }
 
+func cleanPostID(post *model.Post) {
+	post.Id = ""
+}
+
 func cleanAndTrimMessage(message string, trimLength int) string {
 	return trimMessage(cleanMessage(message), trimLength)
 }


### PR DESCRIPTION
This changes the behavior of `/wrangler attach message` to preserve
the timestamp of the original message.

The timestamp was originally ignored and the new message showed up
in the thread based on the time when the attach command was run.
This was done as new messages show up at the bottom of channels
even when they are created with a timestamp sometime before previous
messages in the thread. As this is the current Mattermost behavior,
it initially felt less confusing to proceed in this manner. Upon
further testing, preserving the timestamp of the original message
is far more useful even when dealing with the less-than-ideal
channel behavior mentioned above.