### PR TITLE
Check user authorization for plugin usage before loading web UI

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -62,11 +62,16 @@ func (p *Plugin) handleRouteAPISettings(w http.ResponseWriter, r *http.Request) 
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
+	var enabled bool
+	if p.getConfiguration().EnableWebUI && p.authorizedPluginUser(mattermostUserID) {
+		enabled = true
+	}
+
 	return respondJSON(w,
 		struct {
 			EnableWebUI bool `json:"enable_web_ui"`
 		}{
-			EnableWebUI: p.getConfiguration().EnableWebUI,
+			EnableWebUI: enabled,
 		},
 	)
 }


### PR DESCRIPTION
This prevents Wrangler web elements from loading in for users who
would not be able to use the plugin due to not matching the
`Allowed Email Domain` plugin configuration.