### PR TITLE
Reapply reactions to messages

### DIFF
--- a/server/command_attach_message_test.go
+++ b/server/command_attach_message_test.go
@@ -49,6 +49,13 @@ func TestAttachMessageCommand(t *testing.T) {
 		Type:   model.CHANNEL_DIRECT,
 	}
 
+	reactions := []*model.Reaction{
+		{
+			UserId: model.NewId(),
+			PostId: model.NewId(),
+		},
+	}
+
 	config := &model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: NewString("test.sampledomain.com"),
@@ -64,6 +71,8 @@ func TestAttachMessageCommand(t *testing.T) {
 	api.On("CreatePost", mock.Anything, mock.Anything).Return(mockGeneratePost(), nil)
 	api.On("DeletePost", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil)
 	api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(directChannel, nil)
+	api.On("GetReactions", mock.AnythingOfType("string")).Return(reactions, nil)
+	api.On("AddReaction", mock.Anything).Return(nil, nil)
 	api.On("GetConfig", mock.Anything).Return(config)
 	api.On("LogInfo",
 		mock.AnythingOfTypeArgument("string"),

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -52,6 +52,13 @@ func TestMoveThreadCommand(t *testing.T) {
 		Name:   "target-channel",
 	}
 
+	reactions := []*model.Reaction{
+		{
+			UserId: model.NewId(),
+			PostId: model.NewId(),
+		},
+	}
+
 	config := &model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: NewString("test.sampledomain.com"),
@@ -72,6 +79,8 @@ func TestMoveThreadCommand(t *testing.T) {
 	api.On("GetTeam", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(targetTeam, nil)
 	api.On("CreatePost", mock.Anything, mock.Anything).Return(mockGeneratePost(), nil)
 	api.On("DeletePost", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil)
+	api.On("GetReactions", mock.AnythingOfType("string")).Return(reactions, nil)
+	api.On("AddReaction", mock.Anything).Return(nil, nil)
 	api.On("GetConfig", mock.Anything).Return(config)
 	api.On("LogInfo",
 		mock.AnythingOfTypeArgument("string"),


### PR DESCRIPTION
Previously, reactions were lost when messages were moved to a new
channel or attached to a thread. This adds logic to reapply all the
previous reactions to these messages.