### PR TITLE
Prevent `attach message` command from running with duplicate IDs

### DIFF
--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -25,6 +25,10 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	postToBeAttachedID := args[0]
 	postToAttachToID := args[1]
 
+	if postToBeAttachedID == postToAttachToID {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the two provided message IDs should not be the same"), true, nil
+	}
+
 	postToBeAttached, appErr := p.API.GetPost(postToBeAttachedID)
 	if appErr != nil {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: unable to get message with ID %s; ensure this is correct", postToBeAttachedID)), true, nil
@@ -48,7 +52,7 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	}
 
 	// We now know:
-	// 1. The post IDs are valid.
+	// 1. The post IDs are valid and unique.
 	// 2. The post to be attached is not part of a thread already.
 	// 3. The posts are in the same channel.
 	// 4. The command was run from the original channel with the posts, so they

--- a/server/command_attach_message_test.go
+++ b/server/command_attach_message_test.go
@@ -110,6 +110,13 @@ func TestAttachMessageCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, "Error: missing arguments")
 	})
 
+	t.Run("post IDs are the same", func(t *testing.T) {
+		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToAttachTo.Id, postToAttachTo.Id}, &model.CommandArgs{ChannelId: model.NewId()})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: the two provided message IDs should not be the same")
+	})
+
 	t.Run("post to be attached invalid", func(t *testing.T) {
 		resp, isUserError, err := plugin.runAttachMessageCommand([]string{model.NewId(), postToAttachTo.Id}, &model.CommandArgs{ChannelId: model.NewId()})
 		require.NoError(t, err)


### PR DESCRIPTION
Running `attach message` with the same ID value passed in twice
will now show the proper error message to the user.

```release-note
Prevent `attach message` command from running with duplicate IDs
```