### PR TITLE
Improve post permalinks to handle cross-team moves

### DIFF
--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -58,6 +58,11 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	// 4. The command was run from the original channel with the posts, so they
 	//    are also a member of that channel.
 
+	currentTeam, appErr := p.API.GetTeam(extra.TeamId)
+	if appErr != nil {
+		return nil, false, errors.Wrap(appErr, "failed to lookup lookup team")
+	}
+
 	newRootID := postToAttachTo.Id
 	if len(postToAttachTo.RootId) != 0 {
 		newRootID = postToAttachTo.RootId
@@ -137,7 +142,7 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	if extra.UserId != postToBeAttached.UserId {
 		// The wrangled message was not created by the user running the command.
 		// Send a DM to the user who created it to let them know.
-		err := p.postAttachMessageBotDM(postToBeAttached.UserId, makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, newPost.Id))
+		err := p.postAttachMessageBotDM(postToBeAttached.UserId, makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, currentTeam.Name, newPost.Id))
 		if err != nil {
 			p.API.LogError("Unable to send attach-message DM to user",
 				"error", err.Error(),

--- a/server/command_attach_message_test.go
+++ b/server/command_attach_message_test.go
@@ -48,6 +48,10 @@ func TestAttachMessageCommand(t *testing.T) {
 		Name:   "direct1",
 		Type:   model.CHANNEL_DIRECT,
 	}
+	currentTeam := &model.Team{
+		Id:   model.NewId(),
+		Name: "target-team",
+	}
 
 	reactions := []*model.Reaction{
 		{
@@ -73,6 +77,7 @@ func TestAttachMessageCommand(t *testing.T) {
 	api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(directChannel, nil)
 	api.On("GetReactions", mock.AnythingOfType("string")).Return(reactions, nil)
 	api.On("AddReaction", mock.Anything).Return(nil, nil)
+	api.On("GetTeam", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(currentTeam, nil)
 	api.On("GetConfig", mock.Anything).Return(config)
 	api.On("LogInfo",
 		mock.AnythingOfTypeArgument("string"),

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -207,7 +207,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		"new_channel_id", channelID,
 	)
 
-	newPostLink := makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, newRootPostID)
+	newPostLink := makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, targetTeam.Name, newRootPostID)
 	if extra.UserId != wpl.RootPost().UserId {
 		// The wrangled thread was not started by the user running the command.
 		// Send a DM to the user who created the root message to let them know.

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -193,7 +193,7 @@ func TestMoveThreadCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2"}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, "")))
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
 		assert.Contains(t, resp.Text, fmt.Sprintf(
 			"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
 			targetTeam.Name, targetChannel.Name, 3,

--- a/server/utils.go
+++ b/server/utils.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-func makePostLink(siteURL, postID string) string {
-	return fmt.Sprintf("%s/_redirect/pl/%s", siteURL, postID)
+func makePostLink(siteURL, teamName, postID string) string {
+	return fmt.Sprintf("%s/%s/pl/%s", siteURL, teamName, postID)
 }
 
 func cleanPost(post *model.Post) {


### PR DESCRIPTION
This resolves a bug where it was possible for links to break when
the post being linked to was in a different team.

```release-note
Improve post permalinks to handle cross-team moves
```