### PR TITLE
Move team channel lookup logic to webapp

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -10,14 +10,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
 const (
 	// API V1
-	routeAPISettings            = "/api/v1/settings"
-	routeChannelsforTeamForUser = "/api/v1/channels-for-team-for-user"
+	routeAPISettings = "/api/v1/settings"
 
 	routeProfileImage = "/profile.png"
 )
@@ -27,7 +25,6 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	if err != nil {
 		p.API.LogError("ERROR: ", "Status", strconv.Itoa(status), "Error", err.Error(), "Host", r.Host, "RequestURI", r.RequestURI, "Method", r.Method, "query", r.URL.Query().Encode())
 	}
-	p.API.LogInfo("WRANGLER | OK: ", "Status", strconv.Itoa(status), "Host", r.Host, "RequestURI", r.RequestURI, "Method", r.Method, "query", r.URL.Query().Encode())
 }
 
 // ServeHTTP handles HTTP requests to the plugin.
@@ -42,8 +39,6 @@ func (p *Plugin) serveHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	switch path := r.URL.Path; path {
 	case routeAPISettings:
 		return p.handleRouteAPISettings(w, r)
-	case routeChannelsforTeamForUser:
-		return p.handleChannelsForTeamForUserRequest(w, r)
 	case routeProfileImage:
 		return p.handleProfileImage(w, r)
 	}
@@ -93,50 +88,6 @@ func (p *Plugin) handleProfileImage(w http.ResponseWriter, r *http.Request) (int
 	w.Header().Set("Content-Type", "image/png")
 	io.Copy(w, img)
 
-	return http.StatusOK, nil
-}
-
-// ChannelsForTeamForUserRequest is a request for channel data for a specific team.
-type ChannelsForTeamForUserRequest struct {
-	TeamID string `json:"team_id"`
-}
-
-func (p *Plugin) handleChannelsForTeamForUserRequest(w http.ResponseWriter, r *http.Request) (int, error) {
-	mattermostUserID := r.Header.Get("Mattermost-User-Id")
-	if mattermostUserID == "" {
-		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
-	}
-
-	mtr := &ChannelsForTeamForUserRequest{}
-	err := decodeJSON(mtr, r.Body)
-	if err != nil {
-		return respondErr(w, http.StatusBadRequest, errors.Wrap(err, "could not decode request"))
-	}
-	if mtr.TeamID == "" {
-		return respondErr(w, http.StatusBadRequest, errors.Wrap(err, "could not decode request"))
-	}
-
-	var channelsForUser []*model.Channel
-	channels, appErr := p.API.GetChannelsForTeamForUser(mtr.TeamID, mattermostUserID, false)
-	if appErr != nil {
-		return respondErr(w, http.StatusUnauthorized, errors.Wrap(appErr, "not authorized"))
-	}
-
-	for _, channel := range channels {
-		if channel.IsGroupOrDirect() {
-			continue
-		}
-		channelsForUser = append(channelsForUser, channel)
-	}
-
-	responseJSON, err := json.Marshal(channelsForUser)
-	if err != nil {
-		return respondErr(w, http.StatusUnauthorized, errors.Wrap(err, "could not marshal response"))
-	}
-
-	p.API.LogError(string(responseJSON))
-
-	w.Write(responseJSON)
 	return http.StatusOK, nil
 }
 

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -42,7 +42,7 @@ const manifestStr = `
       },
       {
         "key": "EnableWebUI",
-        "display_name": "Enable Wrangler webapp functionality [ALPHA]",
+        "display_name": "Enable Wrangler webapp functionality [BETA]",
         "type": "bool",
         "help_text": "Enable the work-in-progress Wrangler webapp functionality.",
         "placeholder": "",

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -1,10 +1,9 @@
 import {GlobalState} from 'mattermost-redux/types/store';
 
-import {RECEIVED_PLUGIN_SETTINGS, RECEIVED_CHANNELS_FOR_TEAM} from '../types/wrangler';
+import {RECEIVED_PLUGIN_SETTINGS} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL} from '../types/ui';
 
 import Client from '../client';
-import {GetChannelsForTeamRequest} from '../types/api';
 
 export type GetStateFunc = () => GlobalState;
 export type ActionResult = {
@@ -54,24 +53,6 @@ export function getSettings(): ActionFunc {
         });
 
         return {data: settings};
-    };
-}
-
-export function getChannelsForTeam(teamID: string): ActionFunc {
-    return async (dispatch: DispatchFunc) => {
-        const {data: channels, error} = await Client.getChannelsForTeam({
-            team_id: teamID,
-        } as GetChannelsForTeamRequest);
-        if (error) {
-            return {error};
-        }
-
-        dispatch({
-            type: RECEIVED_CHANNELS_FOR_TEAM,
-            channels,
-        });
-
-        return {data: channels};
     };
 }
 

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -1,9 +1,10 @@
 import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {Client4} from 'mattermost-redux/client';
+import {General} from 'mattermost-redux/constants';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {MoveThreadRequest, GetChannelsForTeamRequest} from '../types/api';
+import {MoveThreadRequest} from '../types/api';
 import id from '../plugin_id';
 
 export default class Client {
@@ -11,13 +12,6 @@ export default class Client {
         return this.doFetch(
             `${this.getAPIV1BaseRoute()}/settings`,
             {method: 'get'},
-        );
-    }
-
-    getChannelsForTeam = async (req: GetChannelsForTeamRequest) => {
-        return this.doFetch(
-            `${this.getAPIV1BaseRoute()}/channels-for-team-for-user`,
-            {method: 'post', body: JSON.stringify(req)},
         );
     }
 

--- a/webapp/src/components/move_thread_modal/index.ts
+++ b/webapp/src/components/move_thread_modal/index.ts
@@ -2,12 +2,14 @@ import {connect} from 'react-redux';
 import {Dispatch, Action, bindActionCreators} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
+import {Client4} from 'mattermost-redux/client';
+import {General} from 'mattermost-redux/constants';
 import {getTeam, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {Team} from 'mattermost-redux/types/teams';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import {isMoveModalVisable, getMoveThreadPostID} from '../../selectors';
-import {closeMoveThreadModal, moveThread, getChannelsForTeam} from '../../actions';
+import {closeMoveThreadModal, moveThread} from '../../actions';
 
 import MoveThreadModal from './move_thread_modal';
 
@@ -42,9 +44,15 @@ function mapStateToProps(state: GlobalState) {
         return myTeams;
     };
 
+    const getChannelsForTeamFunc = (teamID: string) => {
+        const channels = Client4.getChannels(teamID, 0, General.CHANNELS_CHUNK_SIZE);
+        return channels;
+    };
+
     return {
         visible: isMoveModalVisable(state),
         getMyTeams: getMyTeamsFunc,
+        getChannelsForTeam: getChannelsForTeamFunc,
         postID,
         message,
         threadCount,
@@ -55,7 +63,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
     return bindActionCreators({
         closeMoveThreadModal,
         moveThread,
-        getChannelsForTeam,
     }, dispatch);
 }
 

--- a/webapp/src/components/move_thread_modal/move_thread_modal.tsx
+++ b/webapp/src/components/move_thread_modal/move_thread_modal.tsx
@@ -57,8 +57,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
         if (myTeams.length > 0) {
             const firstTeam = myTeams[0];
             firstTeamID = firstTeam.id;
-            const channelResponse = await this.props.getChannelsForTeam(firstTeamID);
-            channels = channelResponse.data;
+            channels = await this.props.getChannelsForTeam(firstTeamID);
             if (channels.length > 0) {
                 const firstChannel = channels[0];
                 firstChannelID = firstChannel.id;
@@ -75,8 +74,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
 
     private handleTeamSelectChange = async (event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLSelectElement>) => {
         const teamID = event.target.value;
-        const channelResponse = await this.props.getChannelsForTeam(teamID);
-        const channels = channelResponse.data;
+        const channels = await this.props.getChannelsForTeam(teamID);
         let firstChannelID = '';
         if (channels.length > 0) {
             const firstChannel = channels[0];

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -32,7 +32,7 @@ const manifest = JSON.parse(`
             },
             {
                 "key": "EnableWebUI",
-                "display_name": "Enable Wrangler webapp functionality [ALPHA]",
+                "display_name": "Enable Wrangler webapp functionality [BETA]",
                 "type": "bool",
                 "help_text": "Enable the work-in-progress Wrangler webapp functionality.",
                 "placeholder": "",

--- a/webapp/src/reducers/index.ts
+++ b/webapp/src/reducers/index.ts
@@ -34,19 +34,9 @@ function getMoveThreadPostID(state = '', action: OpenMoveThreadAction) {
     }
 }
 
-function getChannelsForTeam(state: Channels | null = null, action: ReceivedChannelsForTeamAction) {
-    switch (action.type) {
-    case RECEIVED_CHANNELS_FOR_TEAM:
-        return action.channels;
-    default:
-        return state;
-    }
-}
-
 const rootReducer = combineReducers({
     pluginSettings,
     getMoveThreadPostID,
-    getChannelsForTeam,
     moveThreadModalVisable,
 });
 

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -9,5 +9,3 @@ export const getPluginSettings = (state: GlobalState) => pluginState(state).plug
 export const isMoveModalVisable = (state: GlobalState) => pluginState(state).moveThreadModalVisable;
 
 export const getMoveThreadPostID = (state: GlobalState) => pluginState(state).getMoveThreadPostID;
-
-export const getChannelsForTeamSel = (state: GlobalState) => pluginState(state).getChannelsForTeam;

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -3,7 +3,3 @@ export type MoveThreadRequest = {
     thread_id: string;
     original_channel_id: string;
 }
-
-export type GetChannelsForTeamRequest = {
-    team_id: string;
-}

--- a/webapp/src/types/wrangler.ts
+++ b/webapp/src/types/wrangler.ts
@@ -15,11 +15,4 @@ export type ReceivedPluginSettingsAction = {
     settings: Settings;
 };
 
-export const RECEIVED_CHANNELS_FOR_TEAM = `${id}_received_channels_for_team`;
-
-export type ReceivedChannelsForTeamAction = {
-    type: typeof RECEIVED_CHANNELS_FOR_TEAM;
-    channels: Channels;
-};
-
-export type WranglerActionType = ReceivedPluginSettingsAction | ReceivedChannelsForTeamAction;
+export type WranglerActionType = ReceivedPluginSettingsAction;

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -5,6 +5,9 @@ module.exports = {
         './src/index.ts',
     ],
     resolve: {
+        alias: {
+            src: path.resolve(__dirname, './src/'),
+        },
         modules: [
             'src',
             'node_modules',


### PR DESCRIPTION
This cleans up duplicate logic from the plugin server component for
looking up channels in a team that a user belongs to. The webapp
portion of the plugin now does this directly.

#### Release Note
```release-note
Move team channel lookup logic to webapp
```
