### PR TITLE
Handle missing root posts in redux

### DIFF
--- a/webapp/src/components/move_thread_dropdown/index.ts
+++ b/webapp/src/components/move_thread_dropdown/index.ts
@@ -4,7 +4,8 @@ import {Dispatch, Action, bindActionCreators} from 'redux';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getPost as getPostSel} from 'mattermost-redux/selectors/entities/posts';
+import {getPostThread} from 'mattermost-redux/actions/posts';
 
 import {openMoveThreadModal} from '../../actions';
 
@@ -15,32 +16,39 @@ interface Props {
 }
 
 function mapStateToProps(state: GlobalState, props: Props) {
-    let post = getPost(state, props.postId);
+    const post = getPostSel(state, props.postId);
     const oldSystemMessageOrNull = post ? isSystemMessage(post) : true;
     const systemMessage = isCombinedUserActivityPost(post) || oldSystemMessageOrNull;
-
+    let needRootMessage = false;
+    let rootPostID = props.postId;
     let threadCount = 1;
-    if (post) {
-        if (post.root_id) {
-            post = getPost(state, post.root_id);
-        }
 
-        const postsInThread = state.entities.posts.postsInThread[post.id];
-        if (postsInThread) {
-            threadCount = postsInThread.length + 1;
+    if (post) {
+        threadCount = post.reply_count + 1;
+        if (post.root_id) {
+            rootPostID = post.root_id;
+            const rootPost = getPostSel(state, post.root_id);
+            if (rootPost) {
+                threadCount = rootPost.reply_count + 1;
+            } else {
+                needRootMessage = true;
+            }
         }
     }
 
     return {
-        postId: props.postId,
-        threadCount,
+        postID: props.postId,
         isSystemMessage: systemMessage,
+        threadCount,
+        needRootMessage,
+        rootPostID,
     };
 }
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
     return bindActionCreators({
         openMoveThreadModal,
+        getPostThread,
     }, dispatch);
 }
 

--- a/webapp/src/components/move_thread_dropdown/move_thread_dropdown.tsx
+++ b/webapp/src/components/move_thread_dropdown/move_thread_dropdown.tsx
@@ -4,9 +4,12 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faHatCowboy} from '@fortawesome/free-solid-svg-icons';
 
 interface Props {
-    postId: string;
+    postID: string;
     threadCount: number;
     isSystemMessage: boolean;
+    rootPostID: string;
+    needRootMessage: boolean;
+    getPostThread: Function;
     openMoveThreadModal: Function;
 }
 
@@ -18,11 +21,20 @@ export default class MoveThreadDropdown extends React.PureComponent<Props, State
             event.preventDefault();
         }
 
-        this.props.openMoveThreadModal(this.props.postId);
+        this.props.openMoveThreadModal(this.props.rootPostID);
     };
+
+    private getRootMessage() {
+        this.props.getPostThread(this.props.rootPostID);
+    }
 
     public render() {
         if (this.props.isSystemMessage) {
+            return null;
+        }
+
+        if (this.props.needRootMessage) {
+            this.getRootMessage();
             return null;
         }
 

--- a/webapp/src/components/move_thread_modal/index.ts
+++ b/webapp/src/components/move_thread_modal/index.ts
@@ -6,7 +6,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getTeam, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {Team} from 'mattermost-redux/types/teams';
 import {Channel} from 'mattermost-redux/types/channels';
-import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getPost as getPostSel} from 'mattermost-redux/selectors/entities/posts';
 
 import {isMoveModalVisable, getMoveThreadPostID} from '../../selectors';
 import {closeMoveThreadModal, moveThread} from '../../actions';
@@ -15,22 +15,14 @@ import MoveThreadModal from './move_thread_modal';
 
 function mapStateToProps(state: GlobalState) {
     let postID = getMoveThreadPostID(state);
-    let post = getPost(state, postID);
+    const post = getPostSel(state, postID);
     let message = '';
     let threadCount = 1;
 
     if (post) {
-        if (post.root_id) {
-            post = getPost(state, post.root_id);
-        }
-
+        threadCount = post.reply_count + 1;
         postID = post.id;
         message = post.message;
-
-        const postsInThread = state.entities.posts.postsInThread[postID];
-        if (postsInThread) {
-            threadCount = postsInThread.length + 1;
-        }
     }
 
     const getMyTeamsFunc = () => {


### PR DESCRIPTION
Some scenarios where the post dropdown could be used in the
Mattermost webapp could result in a state where the post of a
thread was available in redux, but the root post was not available.
Some of these cases were not properly handled in the plugin.

This change adds logic for ensuring root posts and their threads
are pulled into redux so that the Wrangler webapp can properly
display and manage them.

Fixes https://mattermost.atlassian.net/browse/MM-25968 and https://mattermost.atlassian.net/browse/MM-26342

#### Release Note
```release-note
Handle missing root posts in redux
```
