### PR TITLE
Change thread message count logic

### DIFF
--- a/webapp/src/components/move_thread_dropdown/index.ts
+++ b/webapp/src/components/move_thread_dropdown/index.ts
@@ -24,12 +24,14 @@ function mapStateToProps(state: GlobalState, props: Props) {
     let threadCount = 1;
 
     if (post) {
-        threadCount = post.reply_count + 1;
         if (post.root_id) {
             rootPostID = post.root_id;
             const rootPost = getPostSel(state, post.root_id);
             if (rootPost) {
-                threadCount = rootPost.reply_count + 1;
+                const postsInThread = state.entities.posts.postsInThread[rootPostID];
+                if (postsInThread) {
+                    threadCount = postsInThread.length + 1;
+                }
             } else {
                 needRootMessage = true;
             }

--- a/webapp/src/components/move_thread_modal/index.ts
+++ b/webapp/src/components/move_thread_modal/index.ts
@@ -20,7 +20,10 @@ function mapStateToProps(state: GlobalState) {
     let threadCount = 1;
 
     if (post) {
-        threadCount = post.reply_count + 1;
+        const postsInThread = state.entities.posts.postsInThread[post.id];
+        if (postsInThread) {
+            threadCount = postsInThread.length + 1;
+        }
         postID = post.id;
         message = post.message;
     }


### PR DESCRIPTION
This change reverts the logic for determining the message count of
a thread back to a previous implementation. The recent attempt at
using the post `reply_count` value seems to be unreliable in
certain cases.

```release-note
Change thread message count logic
```
