### PR TITLE
Add copy thread webapp functionality

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -64,3 +64,12 @@ export function moveThread(postID: string, threadID: string): ActionFunc {
         return {data: null};
     };
 }
+
+export function copyThread(postID: string, threadID: string): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const command = `/wrangler copy thread ${postID} ${threadID}`;
+        await Client.clientExecuteCommand(getState, command);
+
+        return {data: null};
+    };
+}

--- a/webapp/src/components/move_thread_dropdown/index.ts
+++ b/webapp/src/components/move_thread_dropdown/index.ts
@@ -27,14 +27,14 @@ function mapStateToProps(state: GlobalState, props: Props) {
         if (post.root_id) {
             rootPostID = post.root_id;
             const rootPost = getPostSel(state, post.root_id);
-            if (rootPost) {
-                const postsInThread = state.entities.posts.postsInThread[rootPostID];
-                if (postsInThread) {
-                    threadCount = postsInThread.length + 1;
-                }
-            } else {
+            if (!rootPost) {
                 needRootMessage = true;
             }
+        }
+
+        const postsInThread = state.entities.posts.postsInThread[rootPostID];
+        if (postsInThread) {
+            threadCount = postsInThread.length + 1;
         }
     }
 

--- a/webapp/src/components/move_thread_dropdown/move_thread_dropdown.tsx
+++ b/webapp/src/components/move_thread_dropdown/move_thread_dropdown.tsx
@@ -38,9 +38,9 @@ export default class MoveThreadDropdown extends React.PureComponent<Props, State
             return null;
         }
 
-        let content = 'Move Message';
+        let content = 'Move/Copy Message';
         if (this.props.threadCount > 1) {
-            content = 'Move Thread';
+            content = 'Move/Copy Thread';
         }
 
         return (

--- a/webapp/src/components/move_thread_modal/index.ts
+++ b/webapp/src/components/move_thread_modal/index.ts
@@ -9,7 +9,7 @@ import {Channel} from 'mattermost-redux/types/channels';
 import {getPost as getPostSel} from 'mattermost-redux/selectors/entities/posts';
 
 import {isMoveModalVisable, getMoveThreadPostID} from '../../selectors';
-import {closeMoveThreadModal, moveThread} from '../../actions';
+import {closeMoveThreadModal, moveThread, copyThread} from '../../actions';
 
 import MoveThreadModal from './move_thread_modal';
 
@@ -67,6 +67,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
     return bindActionCreators({
         closeMoveThreadModal,
         moveThread,
+        copyThread,
     }, dispatch);
 }
 

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -1,0 +1,4 @@
+export const MessageActionTypeMove = 'move';
+export const MessageActionTypeCopy = 'copy';
+
+export type MessageActionType = typeof MessageActionTypeMove | typeof MessageActionTypeCopy;


### PR DESCRIPTION
The webapp now exposes the plugin functionality to copy messages
and threads. This is provided as an option in the original modal
accessed from the post dropdown menu.

#### Release Note
```release-note
Add copy thread webapp functionality
```
