### PR TITLE
Support multiple allowed email domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Shows version and commit information for the currently-running plugin build.
 
 The following plugin configuration is available:
 
- - Allowed Email Domain: an optional setting to limit plugin usage to specific users
+ - Allowed Email Domain: (Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas.
+   - Example: `domain1.com,domain2.net,domain3.org`
  - Enable Wrangler Command AutoComplete: Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.
  - Max Thread Count Move Size: an optional setting to limit the size of threads that can be moved
  - Enable Moving Threads To Different Teams: Control whether Wrangler is permitted to move message threads from one team to another or not.

--- a/plugin.json
+++ b/plugin.json
@@ -22,7 +22,7 @@
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",
-                "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command."
+                "help_text": "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas."
             },
             {
                 "key": "EnableWebUI",

--- a/server/command.go
+++ b/server/command.go
@@ -160,9 +160,14 @@ func (p *Plugin) authorizedPluginUser(userID string) bool {
 			return false
 		}
 
-		if !strings.HasSuffix(user.Email, config.AllowedEmailDomain) {
-			return false
+		emailDomains := strings.Split(config.AllowedEmailDomain, ",")
+		for _, emailDomain := range emailDomains {
+			if strings.HasSuffix(user.Email, emailDomain) {
+				return true
+			}
 		}
+
+		return false
 	}
 
 	return true

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -40,9 +41,19 @@ func (c *configuration) Clone() *configuration {
 }
 
 func (c *configuration) IsValid() error {
-	_, err := url.Parse(c.AllowedEmailDomain)
-	if err != nil {
-		return errors.Wrap(err, "invalid AllowedEmailDomain")
+	var err error
+
+	if len(c.AllowedEmailDomain) != 0 {
+		emailDomains := strings.Split(c.AllowedEmailDomain, ",")
+		for _, emailDomain := range emailDomains {
+			if len(emailDomain) == 0 {
+				return errors.New("AllowedEmailDomain has a trailing comma")
+			}
+			_, err = url.Parse(emailDomain)
+			if err != nil {
+				return errors.Wrapf(err, "invalid AllowedEmailDomain value %s", emailDomain)
+			}
+		}
 	}
 
 	_, err = parseAndValidateMaxThreadCountMoveSize(c.MoveThreadMaxCount)

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -16,6 +16,27 @@ func TestConfigurationIsValid(t *testing.T) {
 		require.NoError(t, baseConfiguration.IsValid())
 	})
 
+	t.Run("AllowedEmailDomain", func(t *testing.T) {
+		config := baseConfiguration
+
+		t.Run("empty", func(t *testing.T) {
+			config.AllowedEmailDomain = ""
+			require.NoError(t, config.IsValid())
+		})
+		t.Run("full email", func(t *testing.T) {
+			config.AllowedEmailDomain = "user@mattermost.com"
+			require.NoError(t, config.IsValid())
+		})
+		t.Run("multiple domains", func(t *testing.T) {
+			config.AllowedEmailDomain = "mattermost.com,google.com"
+			require.NoError(t, config.IsValid())
+		})
+		t.Run("trailing comma", func(t *testing.T) {
+			config.AllowedEmailDomain = "mattermost.com,google.com,"
+			require.Error(t, config.IsValid())
+		})
+	})
+
 	t.Run("MaxThreadCountMoveSize", func(t *testing.T) {
 		config := baseConfiguration
 

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -36,7 +36,7 @@ const manifestStr = `
         "key": "AllowedEmailDomain",
         "display_name": "Allowed Email Domain",
         "type": "text",
-        "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command.",
+        "help_text": "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas.",
         "placeholder": "",
         "default": null
       },

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -26,7 +26,7 @@ const manifest = JSON.parse(`
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",
-                "help_text": "(Optional) When set, users must have an email ending in this domain to use the wrangler slash command.",
+                "help_text": "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas.",
                 "placeholder": "",
                 "default": null
             },


### PR DESCRIPTION
Multiple allowed email domains can now be specified in the plugin
configuration by listing them with comma separation.

Fixes https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/82

#### Release Note
```release-note
Support multiple allowed email domains
```
