### PR TITLE
Use display names on move summary

### DIFF
--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -109,7 +109,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 	msg := fmt.Sprintf("A thread has been moved: %s\n", newPostLink)
 	msg += fmt.Sprintf(
 		"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
-		targetTeam.Name, targetChannel.Name, wpl.NumPosts(),
+		targetTeam.DisplayName, targetChannel.DisplayName, wpl.NumPosts(),
 	)
 	msg += fmt.Sprintf("Original Thread Root Message:\n%s\n", quoteBlock(originalMessageSummary))
 

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -43,13 +43,15 @@ func TestMoveThreadCommand(t *testing.T) {
 	}
 
 	targetTeam := &model.Team{
-		Id:   model.NewId(),
-		Name: "target-team",
+		Id:          model.NewId(),
+		Name:        "target-team",
+		DisplayName: "Target Team",
 	}
 	targetChannel := &model.Channel{
-		Id:     model.NewId(),
-		TeamId: targetTeam.Id,
-		Name:   "target-channel",
+		Id:          model.NewId(),
+		TeamId:      targetTeam.Id,
+		Name:        "target-channel",
+		DisplayName: "Target Channel",
 	}
 
 	reactions := []*model.Reaction{
@@ -196,7 +198,7 @@ func TestMoveThreadCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
 		assert.Contains(t, resp.Text, fmt.Sprintf(
 			"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
-			targetTeam.Name, targetChannel.Name, 3,
+			targetTeam.DisplayName, targetChannel.DisplayName, 3,
 		))
 		assert.Contains(t, resp.Text, quoteBlock("This is message 1"))
 	})


### PR DESCRIPTION
The target team and channel display names are now listed when a
thread is moved instead of the underlying name values. This should
make the move summaries clearer for users.

Fixes https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/80

#### Release Note
```release-note
Use display names on move summary
```
