### PR TITLE
Add option to hide root message contents in move summary

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -32,7 +32,7 @@ const helpText = `Wrangler Plugin - Slash Command Help
 func getHelp() string {
 	return codeBlock(fmt.Sprintf(
 		helpText,
-		moveThreadUsage,
+		getMoveThreadUsage(),
 		copyThreadUsage,
 		getListChannelsFlagSet().FlagUsages(),
 		getListMessagesFlagSet().FlagUsages(),

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -203,6 +203,20 @@ func TestMoveThreadCommand(t *testing.T) {
 		assert.Contains(t, resp.Text, quoteBlock("This is message 1"))
 	})
 
+	t.Run("move thread successfully, but don't show root message", func(t *testing.T) {
+		require.NoError(t, plugin.configuration.IsValid())
+
+		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2", "--show-root-message-in-summary=false"}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
+		assert.Contains(t, resp.Text, fmt.Sprintf(
+			"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
+			targetTeam.DisplayName, targetChannel.DisplayName, 3,
+		))
+		assert.NotContains(t, resp.Text, "This is message 1")
+	})
+
 	t.Run("thread is above configuration move-maximum", func(t *testing.T) {
 		plugin.setConfiguration(&configuration{MoveThreadMaxCount: "1"})
 		require.NoError(t, plugin.configuration.IsValid())


### PR DESCRIPTION
In certain situations it may be ideal to move a thread and not
include the root message contents in the move-summary message posted
by the plugin. A slash command flag has been added to optionally
hide these message contents when they have been deemed as sensitive.

#### Release Note
```release-note
Add option to hide root message contents in move summary
```
