### PR TITLE
Add webapp option to hide root message contents in move summary

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -56,9 +56,9 @@ export function getSettings(): ActionFunc {
     };
 }
 
-export function moveThread(postID: string, threadID: string): ActionFunc {
+export function moveThread(postID: string, threadID: string, showRootMessage: boolean): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const command = `/wrangler move thread ${postID} ${threadID}`;
+        const command = `/wrangler move thread ${postID} ${threadID} --show-root-message-in-summary=${showRootMessage}`;
         await Client.clientExecuteCommand(getState, command);
 
         return {data: null};

--- a/webapp/src/components/move_thread_modal/move_thread_modal.tsx
+++ b/webapp/src/components/move_thread_modal/move_thread_modal.tsx
@@ -28,6 +28,7 @@ type State = {
     moveThreadButtonText: string;
     actionType: MessageActionType,
     actionWord: string,
+    moveShowRootMessage: boolean,
 }
 
 export default class MoveThreadModal extends React.PureComponent<Props, State> {
@@ -42,6 +43,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
             moveThreadButtonText: this.getMoveButtonText('Move'),
             actionType: MessageActionTypeMove,
             actionWord: 'Move',
+            moveShowRootMessage: true,
         };
     }
 
@@ -105,7 +107,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
         }
 
         if (this.state.actionType === MessageActionTypeMove) {
-            await this.props.moveThread(this.props.postID, this.state.selectedChannel);
+            await this.props.moveThread(this.props.postID, this.state.selectedChannel, this.state.moveShowRootMessage);
         } else {
             await this.props.copyThread(this.props.postID, this.state.selectedChannel);
         }
@@ -152,6 +154,23 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
         if (this.props.threadCount > 1) {
             title = 'Wrangler - ' + actionWord + ' Thread to Another Channel';
             moveMessage = actionWord + ' this thread of ' + this.props.threadCount + ' messages?';
+        }
+
+        let rootMessageCheckbox = null;
+        if (this.state.actionType === MessageActionTypeMove) {
+            rootMessageCheckbox = (
+                <div className='checkbox'>
+                    <label>
+                        <input
+                            type='checkbox'
+                            id='showRootMessageOption'
+                            checked={this.state.moveShowRootMessage}
+                            onChange={() => this.setState({moveShowRootMessage: !this.state.moveShowRootMessage})}
+                        />
+                        {'Show root message in move summary'}
+                    </label>
+                </div>
+            );
         }
 
         return (
@@ -248,6 +267,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
                                 disabled={true}
                                 readOnly={true}
                             />
+                            {rootMessageCheckbox}
                         </Form.Group>
                     </Form>
                     <p><span className='pull-right'>{moveMessage}</span></p>


### PR DESCRIPTION
This exposes the new 'move thread' command functionality to
optionally hide the root message contents in the move thread summary.

#### Release Note
```release-note
Add webapp option to hide root message contents in move summary
```
