### PR TITLE
Add webapp option to attach messages to threads

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -2,6 +2,7 @@ import {GlobalState} from 'mattermost-redux/types/store';
 
 import {RECEIVED_PLUGIN_SETTINGS} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL} from '../types/ui';
+import {INITIALIZE_ATTACH_POST, FINALIZE_ATTACH_POST, RichPost} from '../types/attach';
 
 import Client from '../client';
 
@@ -40,6 +41,27 @@ export function closeMoveThreadModal(): ActionFunc {
     };
 }
 
+export function startAttachingPost(post: RichPost): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
+        dispatch({
+            type: INITIALIZE_ATTACH_POST,
+            post,
+        });
+
+        return {data: null};
+    };
+}
+
+export function finishAttachingPost(): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
+        dispatch({
+            type: FINALIZE_ATTACH_POST,
+        });
+
+        return {data: null};
+    };
+}
+
 export function getSettings(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         const {data: settings, error} = await Client.getSettings();
@@ -68,6 +90,15 @@ export function moveThread(postID: string, threadID: string, showRootMessage: bo
 export function copyThread(postID: string, threadID: string): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const command = `/wrangler copy thread ${postID} ${threadID}`;
+        await Client.clientExecuteCommand(getState, command);
+
+        return {data: null};
+    };
+}
+
+export function attachMessage(postToBeAttachedID: string, postToAttachToID: string): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const command = `/wrangler attach message ${postToBeAttachedID} ${postToAttachToID}`;
         await Client.clientExecuteCommand(getState, command);
 
         return {data: null};

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -1,10 +1,8 @@
 import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {Client4} from 'mattermost-redux/client';
-import {General} from 'mattermost-redux/constants';
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
-import {MoveThreadRequest} from '../types/api';
 import id from '../plugin_id';
 
 export default class Client {
@@ -12,13 +10,6 @@ export default class Client {
         return this.doFetch(
             `${this.getAPIV1BaseRoute()}/settings`,
             {method: 'get'},
-        );
-    }
-
-    moveThread = async (req: MoveThreadRequest) => {
-        return this.doFetch(
-            `${this.getAPIV1BaseRoute()}/move-thread`,
-            {method: 'post', body: JSON.stringify(req)},
         );
     }
 

--- a/webapp/src/components/attach_message_dropdown/attach_message_dropdown.tsx
+++ b/webapp/src/components/attach_message_dropdown/attach_message_dropdown.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faHatCowboy} from '@fortawesome/free-solid-svg-icons';
+
+import {Post} from 'mattermost-redux/types/posts';
+import {Channel} from 'mattermost-redux/types/channels';
+import {UserProfile} from 'mattermost-redux/types/users';
+
+import {RichPost} from 'src/types/attach';
+
+interface Props {
+    post: Post;
+    user: UserProfile;
+    channel: Channel
+    postToBeAttached: RichPost;
+    isSystemMessage: boolean;
+    isValidAttachMessage: boolean;
+    newSidebar: boolean;
+    startAttachingPost: Function;
+    finishAttachingPost: Function;
+    attachMessage: Function;
+}
+
+type State = {}
+
+export default class AttachMessageDropdown extends React.PureComponent<Props, State> {
+    private handleStartAttaching = async (event: React.MouseEvent) => {
+        if (event && event.preventDefault) {
+            event.preventDefault();
+        }
+        const postToBeAttached = {
+            post: this.props.post,
+            user: this.props.user,
+            channel: this.props.channel,
+        };
+        this.props.startAttachingPost(postToBeAttached);
+    };
+
+    private handleAttachMessage = async (event: React.MouseEvent) => {
+        if (event && event.preventDefault) {
+            event.preventDefault();
+        }
+
+        this.props.attachMessage(this.props.postToBeAttached.post.id, this.props.post.id);
+        this.props.finishAttachingPost();
+    };
+
+    public render() {
+        if (this.props.isSystemMessage) {
+            return null;
+        }
+        if (!this.props.isValidAttachMessage && !this.props.postToBeAttached) {
+            return null;
+        }
+        if (this.props.postToBeAttached) {
+            if (this.props.post.id === this.props.postToBeAttached.post.id) {
+                return null;
+            }
+            if (this.props.channel.id !== this.props.postToBeAttached.channel.id) {
+                return null;
+            }
+            if (this.props.post.create_at > this.props.postToBeAttached.post.create_at) {
+                return null;
+            }
+        }
+
+        let dropdownText = 'Attach to Thread';
+        let clickHandler = this.handleStartAttaching;
+        if (this.props.postToBeAttached) {
+            dropdownText = 'Attach to this Thread';
+            clickHandler = this.handleAttachMessage;
+        }
+
+        return (
+            <React.Fragment>
+                <li
+                    className='MenuItem'
+                    role='menuitem'
+                >
+                    <button
+                        className='style--none'
+                        role='presentation'
+                        onClick={clickHandler}
+                    >
+                        <FontAwesomeIcon
+                            className='MenuItem__icon'
+                            icon={faHatCowboy}
+                        />
+                        {dropdownText}
+                    </button>
+                </li>
+            </React.Fragment>
+        );
+    }
+}

--- a/webapp/src/components/attach_message_dropdown/index.ts
+++ b/webapp/src/components/attach_message_dropdown/index.ts
@@ -1,0 +1,52 @@
+import {connect} from 'react-redux';
+import {Dispatch, Action, bindActionCreators} from 'redux';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
+import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+
+import {startAttachingPost, finishAttachingPost, attachMessage} from '../../actions';
+import {getPostToBeAttached} from '../../selectors';
+
+import AttachMessageDropdown from './attach_message_dropdown';
+
+interface Props {
+    postId: string;
+}
+
+function mapStateToProps(state: GlobalState, props: Props) {
+    const post = getPost(state, props.postId);
+    const user = getUser(state, post.user_id);
+    const channel = getChannel(state, post.channel_id);
+    const oldSystemMessageOrNull = post ? isSystemMessage(post) : true;
+    const systemMessage = isCombinedUserActivityPost(post) || oldSystemMessageOrNull;
+
+    let validAttach = false;
+    if (post) {
+        if (!state.entities.posts.postsInThread[post.id] && post.root_id === '') {
+            validAttach = true;
+        }
+    }
+
+    return {
+        post,
+        user,
+        channel,
+        isSystemMessage: systemMessage,
+        isValidAttachMessage: validAttach,
+        postToBeAttached: getPostToBeAttached(state),
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+    return bindActionCreators({
+        startAttachingPost,
+        finishAttachingPost,
+        attachMessage,
+    }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AttachMessageDropdown);

--- a/webapp/src/components/left_sidebar_header/index.ts
+++ b/webapp/src/components/left_sidebar_header/index.ts
@@ -1,0 +1,25 @@
+import {connect} from 'react-redux';
+import {Dispatch, Action, bindActionCreators} from 'redux';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getNewSidebarPreference} from 'mattermost-redux/selectors/entities/preferences';
+
+import {finishAttachingPost} from '../../actions';
+import {getPostToBeAttached} from '../../selectors';
+
+import LeftSidebarHeader from './left_sidebar_header';
+
+function mapStateToProps(state: GlobalState) {
+    return {
+        postToBeAttached: getPostToBeAttached(state),
+        newSidebar: getNewSidebarPreference(state),
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+    return bindActionCreators({
+        finishAttachingPost,
+    }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LeftSidebarHeader);

--- a/webapp/src/components/left_sidebar_header/left_sidebar_header.tsx
+++ b/webapp/src/components/left_sidebar_header/left_sidebar_header.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faHatCowboy} from '@fortawesome/free-solid-svg-icons';
+
+import {Tooltip, OverlayTrigger} from 'react-bootstrap';
+
+import {RichPost} from 'src/types/attach';
+
+import './style.scss';
+
+interface Props {
+    finishAttachingPost: Function;
+    postToBeAttached: RichPost;
+    newSidebar: boolean;
+}
+
+type State = {}
+
+export default class LeftSidebarHeader extends React.PureComponent<Props, State> {
+    private exit = async (event: React.MouseEvent) => {
+        if (event && event.preventDefault) {
+            event.preventDefault();
+        }
+
+        this.props.finishAttachingPost();
+    };
+
+    public render() {
+        const postToBeAttached = this.props.postToBeAttached;
+        if (!postToBeAttached) {
+            return null;
+        }
+
+        const iconStyle = {
+            margin: '0 7px 0 1px',
+        };
+
+        const buttonClass = this.props.newSidebar ? 'SidebarChannelGroupHeader_addButton pull-right' : 'btn-old-sidebar';
+
+        const name = postToBeAttached.user.first_name ? postToBeAttached.user.first_name : postToBeAttached.user.username;
+        const originalMessage = postToBeAttached.post.message;
+        const trimmed = originalMessage.length > length ? originalMessage.substring(0, 75) + '...' : originalMessage;
+        const ttContent = (<div>
+            <p>{'Howdy Partner!'}</p>
+            <p>{'It looks like you are attaching a message to a thread.'}</p>
+            <p>{'Use the post dropdown on the thread you want to attach it to or click the "X" right here to quit.'}</p>
+            <hr/>
+            <p>{name + '\'s message in ' + postToBeAttached.channel.display_name + ':'}</p>
+            <p>{'"' + trimmed + '"'}</p>
+        </div>);
+
+        return (
+            <OverlayTrigger
+                key='githubAssignmentsLink'
+                placement='right'
+                overlay={<Tooltip id='reviewTooltip'>{ttContent}</Tooltip>}
+            >
+                <div className={'wrangler-left-sidebar'}>
+                    <FontAwesomeIcon
+                        className='MenuItem__icon'
+                        style={iconStyle}
+                        icon={faHatCowboy}
+                    />
+                    {'Attaching Message'}
+                    <button
+                        type='button'
+                        className={buttonClass}
+                        aria-label='Exit Wrangler Mode'
+                        onClick={this.exit}
+                    >
+                        <i className='icon-close'/>
+                    </button>
+                </div>
+            </OverlayTrigger>
+        );
+    }
+}

--- a/webapp/src/components/left_sidebar_header/style.scss
+++ b/webapp/src/components/left_sidebar_header/style.scss
@@ -1,0 +1,34 @@
+.wrangler-left-sidebar {
+    margin: .5em 0 .5em;
+    padding: 0 0 0 14px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    animation-name: pulse;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+
+  @keyframes pulse {
+    0% {
+      color: var(--sidebar-text);
+    }
+    50% {
+      color: var(--button-bg);
+    }
+    100% {
+      color: var(--sidebar-text);
+    }
+  }
+}
+
+.wrangler-left-sidebar .btn-old-sidebar {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin-right: 12px;
+  margin-left: auto;
+  float: right;
+  font-size: 1.3em;
+  color: var(--sidebar-text-80);
+}

--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -8,7 +8,9 @@ import reducer from './reducers';
 
 import SetupUI from './components/setup_ui';
 import MoveThreadModal from './components/move_thread_modal';
+import LeftSidebarHeader from './components/left_sidebar_header';
 import MoveThreadDropdown from './components/move_thread_dropdown';
+import AttachMessageDropdown from './components/attach_message_dropdown';
 
 const setupUILater = (registry: PluginRegistry, store: Store<object, Action<object>>): () => Promise<void> => async () => {
     registry.registerReducer(reducer);
@@ -17,7 +19,9 @@ const setupUILater = (registry: PluginRegistry, store: Store<object, Action<obje
 
     if (settings.data.enable_web_ui) {
         registry.registerRootComponent(MoveThreadModal);
+        registry.registerLeftSidebarHeaderComponent(LeftSidebarHeader);
         registry.registerPostDropdownMenuComponent(MoveThreadDropdown);
+        registry.registerPostDropdownMenuComponent(AttachMessageDropdown);
     }
 };
 

--- a/webapp/src/reducers/index.ts
+++ b/webapp/src/reducers/index.ts
@@ -1,7 +1,8 @@
 import {combineReducers} from 'redux';
 
-import {RECEIVED_PLUGIN_SETTINGS, ReceivedPluginSettingsAction, RECEIVED_CHANNELS_FOR_TEAM, ReceivedChannelsForTeamAction, Settings, Channels} from '../types/wrangler';
+import {RECEIVED_PLUGIN_SETTINGS, ReceivedPluginSettingsAction, Settings} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL, UIActionType, OpenMoveThreadAction} from '../types/ui';
+import {INITIALIZE_ATTACH_POST, FINALIZE_ATTACH_POST, AttachPostInitializeAction} from '../types/attach';
 
 function pluginSettings(state: Settings | null = null, action: ReceivedPluginSettingsAction) {
     switch (action.type) {
@@ -34,9 +35,21 @@ function getMoveThreadPostID(state = '', action: OpenMoveThreadAction) {
     }
 }
 
+function postToBeAttached(state = '', action: AttachPostInitializeAction) {
+    switch (action.type) {
+    case INITIALIZE_ATTACH_POST:
+        return action.post;
+    case FINALIZE_ATTACH_POST:
+        return '';
+    default:
+        return state;
+    }
+}
+
 const rootReducer = combineReducers({
     pluginSettings,
     getMoveThreadPostID,
+    postToBeAttached,
     moveThreadModalVisable,
 });
 

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -9,3 +9,5 @@ export const getPluginSettings = (state: GlobalState) => pluginState(state).plug
 export const isMoveModalVisable = (state: GlobalState) => pluginState(state).moveThreadModalVisable;
 
 export const getMoveThreadPostID = (state: GlobalState) => pluginState(state).getMoveThreadPostID;
+
+export const getPostToBeAttached = (state: GlobalState) => pluginState(state).postToBeAttached;

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -1,5 +1,0 @@
-export type MoveThreadRequest = {
-    post_id: string;
-    thread_id: string;
-    original_channel_id: string;
-}

--- a/webapp/src/types/attach.ts
+++ b/webapp/src/types/attach.ts
@@ -1,0 +1,26 @@
+import {Post} from 'mattermost-redux/types/posts';
+import {UserProfile} from 'mattermost-redux/types/users';
+import {Channel} from 'mattermost-redux/types/channels';
+
+import id from '../plugin_id';
+
+export type RichPost = {
+    post: Post;
+    user: UserProfile;
+    channel: Channel;
+}
+
+export const INITIALIZE_ATTACH_POST = `${id}_init_attach_post`;
+
+export type AttachPostInitializeAction = {
+    type: typeof INITIALIZE_ATTACH_POST;
+    post: RichPost;
+};
+
+export const FINALIZE_ATTACH_POST = `${id}_finalize_attach_post`;
+
+export type AttachPostFinalizeAction = {
+    type: typeof FINALIZE_ATTACH_POST;
+};
+
+export type AttachAction = AttachPostInitializeAction | AttachPostFinalizeAction;


### PR DESCRIPTION
This introduces the ability to attach unthreaded messages to
threads via the webapp UI. This is done by introducing a new
asynchronous flow where the user selects a message to attach and
then later attaches it to a selected thread by using post dropdowns.

While this flow is underway, a new sidebar element will remind
users of the context of their in-progress message attachment and
will allow them to cancel it if they wish.

#### Release Note
```release-note
Add webapp option to attach messages to threads
```
