### PR TITLE
Add permitted plugin user control

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Shows version and commit information for the currently-running plugin build.
 
 The following plugin configuration is available:
 
+ - Permitted Wrangler Users: Choose who is allowed to use the Wrangler plugin.
  - Allowed Email Domain: (Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas.
    - Example: `domain1.com,domain2.net,domain3.org`
  - Enable Wrangler Command AutoComplete: Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.

--- a/plugin.json
+++ b/plugin.json
@@ -19,6 +19,23 @@
         "footer": "",
         "settings": [
             {
+                "key": "PermittedWranglerUsers",
+                "display_name": "Permitted Wrangler Users",
+                "type": "dropdown",
+                "help_text": "Choose who is allowed to use the Wrangler plugin. (Other permissions below still apply)",
+                "default": "system-admins",
+                "options": [{
+                    "display_name": "System administrators only",
+                    "value": "system-admins"
+                }, {
+                    "display_name": "System administrators and users from the 'Allowed Email Domain' list",
+                    "value": "system-admins-and-email-domain"
+                }, {
+                    "display_name": "All users",
+                    "value": "all-users"
+                }]
+            },
+            {
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -14,135 +14,161 @@ import (
 func TestCommand(t *testing.T) {
 	context := &plugin.Context{}
 
-	commandUser := &model.User{
+	user := &model.User{
 		Id:    model.NewId(),
 		Email: "user@emaildomain.com",
 	}
+	adminUser := &model.User{
+		Id:    model.NewId(),
+		Email: "admin@admindomain.com",
+		Roles: model.SYSTEM_ADMIN_ROLE_ID,
+	}
 
 	api := &plugintest.API{}
-	api.On("GetUser", commandUser.Id).Return(commandUser, nil)
+	api.On("GetUser", adminUser.Id).Return(adminUser, nil)
+	api.On("GetUser", user.Id).Return(user, nil)
 	api.On("GetUser", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil, &model.AppError{DetailedError: "invalid user"})
+	api.On("LogWarn", mock.AnythingOfTypeArgument("string")).Return(nil)
 
 	var plugin Plugin
 	plugin.SetAPI(api)
+	plugin.setConfiguration(&configuration{
+		PermittedWranglerUsers: permittedUserAllUsers,
+	})
 
 	t.Run("args", func(t *testing.T) {
 		t.Run("no args", func(t *testing.T) {
-			args := &model.CommandArgs{}
+			args := &model.CommandArgs{UserId: user.Id}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, resp.Text, getHelp())
+			require.Equal(t, getHelp(), resp.Text)
 		})
 
 		t.Run("one arg", func(t *testing.T) {
-			args := &model.CommandArgs{Command: "one"}
+			args := &model.CommandArgs{UserId: user.Id, Command: "one"}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, resp.Text, getHelp())
+			require.Equal(t, getHelp(), resp.Text)
 		})
 
 		t.Run("two args, invalid command", func(t *testing.T) {
-			args := &model.CommandArgs{Command: "one two"}
+			args := &model.CommandArgs{UserId: user.Id, Command: "one two"}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, resp.Text, getHelp())
+			require.Equal(t, getHelp(), resp.Text)
 		})
 
 		t.Run("move command", func(t *testing.T) {
 			t.Run("missing extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler move"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler move"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler move invalid"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler move invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 		})
 
 		t.Run("copy command", func(t *testing.T) {
 			t.Run("missing extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler copy"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler copy"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler copy invalid"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler copy invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 		})
 
 		t.Run("attach command", func(t *testing.T) {
 			t.Run("missing extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler attach"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler attach"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler attach invalid"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler attach invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 		})
 
 		t.Run("list command", func(t *testing.T) {
 			t.Run("missing extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler list"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler list"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
-				args := &model.CommandArgs{Command: "wrangler list invalid"}
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler list invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, resp.Text, getHelp())
+				require.Equal(t, getHelp(), resp.Text)
 			})
 		})
 	})
 
 	t.Run("info command", func(t *testing.T) {
-		args := &model.CommandArgs{Command: "wrangler info"}
+		args := &model.CommandArgs{UserId: user.Id, Command: "wrangler info"}
 		resp, appErr := plugin.ExecuteCommand(context, args)
 		require.Nil(t, appErr)
 		infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
 		require.NoError(t, err)
 		assert.False(t, userError)
-		assert.Equal(t, resp, infoResp)
+		assert.Equal(t, infoResp, resp)
 	})
 
-	t.Run("allowed email domain", func(t *testing.T) {
-		t.Run("enabled, user not in domain", func(t *testing.T) {
+	t.Run("permissions", func(t *testing.T) {
+		t.Run("empty permission configuration", func(t *testing.T) {
 			plugin.setConfiguration(&configuration{
-				AllowedEmailDomain: "baddomain.com",
+				PermittedWranglerUsers: "",
+				AllowedEmailDomain:     "emaildomain.com",
 			})
 			args := &model.CommandArgs{
-				UserId:  commandUser.Id,
+				UserId:  user.Id,
 				Command: "wrangler info",
 			}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			assert.Equal(t, resp.Text, "Permission denied. Please talk to your system administrator to get access.")
+			assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
 		})
 
-		t.Run("enabled, user in domain", func(t *testing.T) {
+		t.Run("invalid permission configuration", func(t *testing.T) {
 			plugin.setConfiguration(&configuration{
-				AllowedEmailDomain: "emaildomain.com",
+				PermittedWranglerUsers: "invalid",
+				AllowedEmailDomain:     "emaildomain.com",
 			})
 			args := &model.CommandArgs{
-				UserId:  commandUser.Id,
+				UserId:  user.Id,
+				Command: "wrangler info",
+			}
+			resp, appErr := plugin.ExecuteCommand(context, args)
+			require.Nil(t, appErr)
+			assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
+		})
+
+		t.Run("system admins only", func(t *testing.T) {
+			plugin.setConfiguration(&configuration{
+				PermittedWranglerUsers: permittedUserSystemAdmins,
+				AllowedEmailDomain:     "emaildomain.com",
+			})
+			args := &model.CommandArgs{
+				UserId:  adminUser.Id,
 				Command: "wrangler info",
 			}
 			resp, appErr := plugin.ExecuteCommand(context, args)
@@ -150,29 +176,45 @@ func TestCommand(t *testing.T) {
 			infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
 			require.NoError(t, err)
 			assert.False(t, userError)
-			assert.Equal(t, resp, infoResp)
+			assert.Equal(t, infoResp, resp)
 		})
 
-		t.Run("enabled, invalid user", func(t *testing.T) {
+		t.Run("system admins only and not admin", func(t *testing.T) {
 			plugin.setConfiguration(&configuration{
-				AllowedEmailDomain: "emaildomain.com",
+				PermittedWranglerUsers: permittedUserSystemAdmins,
+				AllowedEmailDomain:     "emaildomain.com",
 			})
 			args := &model.CommandArgs{
-				UserId:  model.NewId(),
+				UserId:  user.Id,
 				Command: "wrangler info",
 			}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			assert.Equal(t, resp.Text, "Permission denied. Please talk to your system administrator to get access.")
+			assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
 		})
 
-		t.Run("multiple domains", func(t *testing.T) {
-			t.Run("user in first domain", func(t *testing.T) {
+		t.Run("allowed email domain", func(t *testing.T) {
+			t.Run("enabled, user not in domain", func(t *testing.T) {
 				plugin.setConfiguration(&configuration{
-					AllowedEmailDomain: "emaildomain.com,anotherdomain.com",
+					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+					AllowedEmailDomain:     "baddomain.com",
 				})
 				args := &model.CommandArgs{
-					UserId:  commandUser.Id,
+					UserId:  user.Id,
+					Command: "wrangler info",
+				}
+				resp, appErr := plugin.ExecuteCommand(context, args)
+				require.Nil(t, appErr)
+				assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
+			})
+
+			t.Run("enabled, user in domain", func(t *testing.T) {
+				plugin.setConfiguration(&configuration{
+					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+					AllowedEmailDomain:     "emaildomain.com",
+				})
+				args := &model.CommandArgs{
+					UserId:  user.Id,
 					Command: "wrangler info",
 				}
 				resp, appErr := plugin.ExecuteCommand(context, args)
@@ -180,16 +222,30 @@ func TestCommand(t *testing.T) {
 				infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
 				require.NoError(t, err)
 				assert.False(t, userError)
-				assert.Equal(t, resp, infoResp)
+				assert.Equal(t, infoResp, resp)
 			})
 
-			t.Run("user in second domain", func(t *testing.T) {
-				commandUser.Email = "user@anotherdomain.com"
+			t.Run("enabled, invalid user", func(t *testing.T) {
 				plugin.setConfiguration(&configuration{
-					AllowedEmailDomain: "emaildomain.com,anotherdomain.com",
+					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+					AllowedEmailDomain:     "emaildomain.com",
 				})
 				args := &model.CommandArgs{
-					UserId:  commandUser.Id,
+					UserId:  model.NewId(),
+					Command: "wrangler info",
+				}
+				resp, appErr := plugin.ExecuteCommand(context, args)
+				require.Nil(t, appErr)
+				assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
+			})
+
+			t.Run("email domain setting is empty", func(t *testing.T) {
+				plugin.setConfiguration(&configuration{
+					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+					AllowedEmailDomain:     "",
+				})
+				args := &model.CommandArgs{
+					UserId:  user.Id,
 					Command: "wrangler info",
 				}
 				resp, appErr := plugin.ExecuteCommand(context, args)
@@ -197,38 +253,77 @@ func TestCommand(t *testing.T) {
 				infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
 				require.NoError(t, err)
 				assert.False(t, userError)
-				assert.Equal(t, resp, infoResp)
+				assert.Equal(t, infoResp, resp)
 			})
 
-			t.Run("user in neither domain", func(t *testing.T) {
-				commandUser.Email = "user@anotherbaddomain.com"
-				plugin.setConfiguration(&configuration{
-					AllowedEmailDomain: "emaildomain.com,anotherdomain.com",
+			t.Run("multiple domains", func(t *testing.T) {
+				t.Run("user in first domain", func(t *testing.T) {
+					plugin.setConfiguration(&configuration{
+						PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+						AllowedEmailDomain:     "emaildomain.com,anotherdomain.com",
+					})
+					args := &model.CommandArgs{
+						UserId:  user.Id,
+						Command: "wrangler info",
+					}
+					resp, appErr := plugin.ExecuteCommand(context, args)
+					require.Nil(t, appErr)
+					infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
+					require.NoError(t, err)
+					assert.False(t, userError)
+					assert.Equal(t, infoResp, resp)
 				})
-				args := &model.CommandArgs{
-					UserId:  commandUser.Id,
-					Command: "wrangler info",
-				}
-				resp, appErr := plugin.ExecuteCommand(context, args)
-				require.Nil(t, appErr)
-				assert.Equal(t, resp.Text, "Permission denied. Please talk to your system administrator to get access.")
-			})
 
-			t.Run("user is a direct email match", func(t *testing.T) {
-				commandUser.Email = "user1@test.com"
-				plugin.setConfiguration(&configuration{
-					AllowedEmailDomain: "emaildomain.com,anotherdomain.com,user1@test.com",
+				t.Run("user in second domain", func(t *testing.T) {
+					user.Email = "user@anotherdomain.com"
+					plugin.setConfiguration(&configuration{
+						PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+						AllowedEmailDomain:     "emaildomain.com,anotherdomain.com",
+					})
+					args := &model.CommandArgs{
+						UserId:  user.Id,
+						Command: "wrangler info",
+					}
+					resp, appErr := plugin.ExecuteCommand(context, args)
+					require.Nil(t, appErr)
+					infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
+					require.NoError(t, err)
+					assert.False(t, userError)
+					assert.Equal(t, infoResp, resp)
 				})
-				args := &model.CommandArgs{
-					UserId:  commandUser.Id,
-					Command: "wrangler info",
-				}
-				resp, appErr := plugin.ExecuteCommand(context, args)
-				require.Nil(t, appErr)
-				infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
-				require.NoError(t, err)
-				assert.False(t, userError)
-				assert.Equal(t, resp, infoResp)
+
+				t.Run("user in neither domain", func(t *testing.T) {
+					user.Email = "user@anotherbaddomain.com"
+					plugin.setConfiguration(&configuration{
+						PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+						AllowedEmailDomain:     "emaildomain.com,anotherdomain.com",
+					})
+					args := &model.CommandArgs{
+						UserId:  user.Id,
+						Command: "wrangler info",
+					}
+					resp, appErr := plugin.ExecuteCommand(context, args)
+					require.Nil(t, appErr)
+					assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
+				})
+
+				t.Run("user is a direct email match", func(t *testing.T) {
+					user.Email = "user1@test.com"
+					plugin.setConfiguration(&configuration{
+						PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+						AllowedEmailDomain:     "emaildomain.com,anotherdomain.com,user1@test.com",
+					})
+					args := &model.CommandArgs{
+						UserId:  user.Id,
+						Command: "wrangler info",
+					}
+					resp, appErr := plugin.ExecuteCommand(context, args)
+					require.Nil(t, appErr)
+					infoResp, userError, err := plugin.runInfoCommand([]string{}, nil)
+					require.NoError(t, err)
+					assert.False(t, userError)
+					assert.Equal(t, infoResp, resp)
+				})
 			})
 		})
 	})

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -10,6 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	permittedUserSystemAdmins         = "system-admins"
+	permittedUserSystemAdminsAndEmail = "system-admins-and-email-domain"
+	permittedUserAllUsers             = "all-users"
+)
+
 // configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration. Any public fields will be
 // deserialized from the Mattermost server configuration in OnConfigurationChange.
@@ -22,7 +28,9 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	AllowedEmailDomain        string
+	PermittedWranglerUsers string
+	AllowedEmailDomain     string
+
 	EnableWebUI               bool
 	CommandAutoCompleteEnable bool
 

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -33,6 +33,28 @@ const manifestStr = `
     "footer": "",
     "settings": [
       {
+        "key": "PermittedWranglerUsers",
+        "display_name": "Permitted Wrangler Users",
+        "type": "dropdown",
+        "help_text": "Choose who is allowed to use the Wrangler plugin. (Other permissions below still apply)",
+        "placeholder": "",
+        "default": "system-admins",
+        "options": [
+          {
+            "display_name": "System administrators only",
+            "value": "system-admins"
+          },
+          {
+            "display_name": "System administrators and users from the 'Allowed Email Domain' list",
+            "value": "system-admins-and-email-domain"
+          },
+          {
+            "display_name": "All users",
+            "value": "all-users"
+          }
+        ]
+      },
+      {
         "key": "AllowedEmailDomain",
         "display_name": "Allowed Email Domain",
         "type": "text",

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -23,6 +23,28 @@ const manifest = JSON.parse(`
         "footer": "",
         "settings": [
             {
+                "key": "PermittedWranglerUsers",
+                "display_name": "Permitted Wrangler Users",
+                "type": "dropdown",
+                "help_text": "Choose who is allowed to use the Wrangler plugin. (Other permissions below still apply)",
+                "placeholder": "",
+                "default": "system-admins",
+                "options": [
+                    {
+                        "display_name": "System administrators only",
+                        "value": "system-admins"
+                    },
+                    {
+                        "display_name": "System administrators and users from the 'Allowed Email Domain' list",
+                        "value": "system-admins-and-email-domain"
+                    },
+                    {
+                        "display_name": "All users",
+                        "value": "all-users"
+                    }
+                ]
+            },
+            {
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",


### PR DESCRIPTION
This new plugin configuration option provides better control over
which users are allowed to access Wrangler functionality. System
administrators can now be granted access separately from the email
domain controls that were previously in place.

Partially addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/91

#### Release Note
```release-note
Add permitted plugin user control
```
