### PR TITLE
Handle attach message post dropdown for system messages

### DIFF
--- a/webapp/src/components/attach_message_dropdown/index.ts
+++ b/webapp/src/components/attach_message_dropdown/index.ts
@@ -19,10 +19,15 @@ interface Props {
 
 function mapStateToProps(state: GlobalState, props: Props) {
     const post = getPost(state, props.postId);
-    const user = getUser(state, post.user_id);
-    const channel = getChannel(state, post.channel_id);
     const oldSystemMessageOrNull = post ? isSystemMessage(post) : true;
     const systemMessage = isCombinedUserActivityPost(post) || oldSystemMessageOrNull;
+
+    let user = null;
+    let channel = null;
+    if (!systemMessage) {
+        user = getUser(state, post.user_id);
+        channel = getChannel(state, post.channel_id);
+    }
 
     let validAttach = false;
     if (post) {


### PR DESCRIPTION
System messages do not have all of the standard properties that are
required to display the 'attach message' dropdown. This change
corrects a bug related to this that caused a webapp crash.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/99

#### Release Note
```release-note
Handle attach message post dropdown for system messages
```
