### PR TITLE
Remove 'move thread' message stats table

### DIFF
--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -135,11 +135,10 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		}
 	}
 
-	msg := fmt.Sprintf("A thread has been moved: %s\n", newPostLink)
-	msg += fmt.Sprintf(
-		"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
-		targetTeam.DisplayName, targetChannel.DisplayName, wpl.NumPosts(),
-	)
+	msg := fmt.Sprintf("A thread with %d messages has been moved: %s\n", wpl.NumPosts(), newPostLink)
+	if wpl.NumPosts() == 1 {
+		msg = fmt.Sprintf("A message has been moved: %s\n", newPostLink)
+	}
 	if showRootMessageInSummary {
 		msg += fmt.Sprintf("Original Thread Root Message:\n%s\n",
 			quoteBlock(cleanAndTrimMessage(

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -247,11 +247,7 @@ func TestMoveThreadCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2"}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
-		assert.Contains(t, resp.Text, fmt.Sprintf(
-			"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
-			targetTeam.DisplayName, targetChannel.DisplayName, 3,
-		))
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread with 3 messages has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
 		assert.Contains(t, resp.Text, quoteBlock("This is message 1"))
 	})
 
@@ -261,11 +257,7 @@ func TestMoveThreadCommand(t *testing.T) {
 		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2", "--show-root-message-in-summary=false"}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)
 		assert.False(t, isUserError)
-		assert.Contains(t, resp.Text, fmt.Sprintf("A thread has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
-		assert.Contains(t, resp.Text, fmt.Sprintf(
-			"\n| Team | Channel | Messages |\n| -- | -- | -- |\n| %s | %s | %d |\n\n",
-			targetTeam.DisplayName, targetChannel.DisplayName, 3,
-		))
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread with 3 messages has been moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
 		assert.NotContains(t, resp.Text, "This is message 1")
 	})
 


### PR DESCRIPTION
This greatly simplifies the move summary message posted by Wrangler.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/101

#### Release Note
```release-note
Remove 'move thread' message stats table
```
