### PR TITLE
Add silent thread move option

### DIFF
--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -17,23 +17,28 @@ const (
 %s`
 
 	flagMoveThreadShowMessageSummary = "show-root-message-in-summary"
+	flagMoveThreadSilent             = "silent"
 )
 
 func getMoveThreadFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("move thread", pflag.ContinueOnError)
 	flagSet.Bool(flagMoveThreadShowMessageSummary, true, "Show the root message in the post-move summary")
+	flagSet.Bool(flagMoveThreadSilent, false, "Silence all Wrangler summary messages and user DMs when moving the thread")
 
 	return flagSet
 }
 
-func parseMoveThreadFlagArgs(args []string) (bool, error) {
+func parseMoveThreadFlagArgs(args []string) (bool, bool, error) {
 	flagSet := getMoveThreadFlagSet()
 	err := flagSet.Parse(args)
 	if err != nil {
-		return false, errors.Wrap(err, "unable to parse move thread flag args")
+		return false, false, errors.Wrap(err, "unable to parse move thread flag args")
 	}
 
-	return flagSet.GetBool(flagMoveThreadShowMessageSummary)
+	showMessageSummary, _ := flagSet.GetBool(flagMoveThreadShowMessageSummary)
+	silent, _ := flagSet.GetBool(flagMoveThreadSilent)
+
+	return showMessageSummary, silent, nil
 }
 
 func getMoveThreadUsage() string {
@@ -48,7 +53,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 	if len(args) < 2 {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getMoveThreadMessage()), true, nil
 	}
-	showRootMessageInSummary, err := parseMoveThreadFlagArgs(args)
+	showRootMessageInSummary, silent, err := parseMoveThreadFlagArgs(args)
 	if err != nil {
 		return nil, false, err
 	}
@@ -98,15 +103,17 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 		return nil, false, err
 	}
 
-	_, appErr = p.API.CreatePost(&model.Post{
-		UserId:    p.BotUserID,
-		RootId:    newRootPost.Id,
-		ParentId:  newRootPost.Id,
-		ChannelId: channelID,
-		Message:   "This thread was moved from another channel",
-	})
-	if appErr != nil {
-		return nil, false, errors.Wrap(appErr, "unable to create new bot post")
+	if !silent {
+		_, appErr = p.API.CreatePost(&model.Post{
+			UserId:    p.BotUserID,
+			RootId:    newRootPost.Id,
+			ParentId:  newRootPost.Id,
+			ChannelId: channelID,
+			Message:   "This thread was moved from another channel",
+		})
+		if appErr != nil {
+			return nil, false, errors.Wrap(appErr, "unable to create new bot post")
+		}
 	}
 
 	// Cleanup is handled by simply deleting the root post. Any comments/replies
@@ -123,6 +130,11 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 	)
 
 	newPostLink := makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, targetTeam.Name, newRootPost.Id)
+
+	if silent {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("A thread with %d message(s) has been silently moved: %s\n", wpl.NumPosts(), newPostLink)), false, nil
+	}
+
 	if extra.UserId != wpl.RootPost().UserId {
 		// The wrangled thread was not started by the user running the command.
 		// Send a DM to the user who created the root message to let them know.

--- a/server/command_move_thread_test.go
+++ b/server/command_move_thread_test.go
@@ -261,6 +261,16 @@ func TestMoveThreadCommand(t *testing.T) {
 		assert.NotContains(t, resp.Text, "This is message 1")
 	})
 
+	t.Run("move thread successfully, but silenced", func(t *testing.T) {
+		require.NoError(t, plugin.configuration.IsValid())
+
+		resp, isUserError, err := plugin.runMoveThreadCommand([]string{"id1", "id2", "--silent"}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, fmt.Sprintf("A thread with 3 message(s) has been silently moved: %s", makePostLink(*config.ServiceSettings.SiteURL, targetTeam.Name, "")))
+		assert.NotContains(t, resp.Text, "This is message 1")
+	})
+
 	t.Run("thread is above configuration move-maximum", func(t *testing.T) {
 		plugin.setConfiguration(&configuration{MoveThreadMaxCount: "1"})
 		require.NoError(t, plugin.configuration.IsValid())


### PR DESCRIPTION
The 'move thread' command now has a 'silent' flag which can be
used to suppress all Wrangler summary messages along with any
DMs that would be sent when moving the thread.

Addresses https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/105

#### Release Note
```release-note
Add silent thread move option
```
