### PR TITLE
Add webapp option to silence Wrangler informational move messages

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -102,9 +102,9 @@ export function getSettings(): ActionFunc {
     };
 }
 
-export function moveThread(postID: string, channelID: string, showRootMessage: boolean): ActionFunc {
+export function moveThread(postID: string, channelID: string, showRootMessage: boolean, silent: boolean): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const command = `/wrangler move thread ${postID} ${channelID} --show-root-message-in-summary=${showRootMessage}`;
+        const command = `/wrangler move thread ${postID} ${channelID} --show-root-message-in-summary=${showRootMessage} --silent=${silent}`;
         await Client.clientExecuteCommand(getState, command);
 
         return {data: null};

--- a/webapp/src/components/move_thread_modal/move_thread_modal.tsx
+++ b/webapp/src/components/move_thread_modal/move_thread_modal.tsx
@@ -29,6 +29,7 @@ type State = {
     actionType: MessageActionType,
     actionWord: string,
     moveShowRootMessage: boolean,
+    moveSilent: boolean,
 }
 
 export default class MoveThreadModal extends React.PureComponent<Props, State> {
@@ -44,6 +45,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
             actionType: MessageActionTypeMove,
             actionWord: 'Move',
             moveShowRootMessage: true,
+            moveSilent: false,
         };
     }
 
@@ -107,7 +109,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
         }
 
         if (this.state.actionType === MessageActionTypeMove) {
-            await this.props.moveThread(this.props.postID, this.state.selectedChannel, this.state.moveShowRootMessage);
+            await this.props.moveThread(this.props.postID, this.state.selectedChannel, this.state.moveShowRootMessage, this.state.moveSilent);
         } else {
             await this.props.copyThread(this.props.postID, this.state.selectedChannel);
         }
@@ -156,19 +158,32 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
             moveMessage = actionWord + ' this thread of ' + this.props.threadCount + ' messages?';
         }
 
-        let rootMessageCheckbox = null;
+        let moveCheckboxes = null;
         if (this.state.actionType === MessageActionTypeMove) {
-            rootMessageCheckbox = (
-                <div className='checkbox'>
-                    <label>
-                        <input
-                            type='checkbox'
-                            id='showRootMessageOption'
-                            checked={this.state.moveShowRootMessage}
-                            onChange={() => this.setState({moveShowRootMessage: !this.state.moveShowRootMessage})}
-                        />
-                        {'Show root message in move summary'}
-                    </label>
+            moveCheckboxes = (
+                <div>
+                    <div className='checkbox'>
+                        <label>
+                            <input
+                                type='checkbox'
+                                id='showRootMessageOption'
+                                checked={this.state.moveShowRootMessage}
+                                onChange={() => this.setState({moveShowRootMessage: !this.state.moveShowRootMessage})}
+                            />
+                            {'Show root message in move summary'}
+                        </label>
+                    </div>
+                    <div className='checkbox'>
+                        <label>
+                            <input
+                                type='checkbox'
+                                id='showSilenceOption'
+                                checked={this.state.moveSilent}
+                                onChange={() => this.setState({moveSilent: !this.state.moveSilent})}
+                            />
+                            {'Silence all Wrangler informational messages'}
+                        </label>
+                    </div>
                 </div>
             );
         }
@@ -267,7 +282,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
                                 disabled={true}
                                 readOnly={true}
                             />
-                            {rootMessageCheckbox}
+                            {moveCheckboxes}
                         </Form.Group>
                     </Form>
                     <p><span className='pull-right'>{moveMessage}</span></p>


### PR DESCRIPTION
A checkbox has been added to allow users to control whether the
Wrangler informational messages are posted or not when moving
threads. This behavior is available from the underlying plugin
command's `--silent` flag.

Fixes https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/105

#### Release Note
```release-note
Add webapp option to silence Wrangler informational move messages
```
