### PR TITLE
Clean header markdown from move summary messages

### DIFF
--- a/server/command_list_messages_test.go
+++ b/server/command_list_messages_test.go
@@ -104,30 +104,56 @@ func TestMessagelListCommand(t *testing.T) {
 
 func TestCleanMessage(t *testing.T) {
 	tests := []struct {
-		name    string
-		message string
+		name     string
+		message  string
+		expected string
 	}{
 		{
-			name:    "no cleanup needed",
-			message: "short",
+			name:     "no cleanup needed",
+			message:  "short",
+			expected: "short",
 		},
 		{
-			name:    "remove codeblock",
-			message: "```code goes here```",
+			name:     "remove codeblock",
+			message:  "```code goes here```",
+			expected: "code goes here",
 		},
 		{
-			name:    "remove newlines",
-			message: "this message \n has multiple \n newlines \n probably",
+			name:     "remove newlines",
+			message:  "this message \n has multiple \n newlines \n probably",
+			expected: "this message  |  has multiple  |  newlines  |  probably",
 		},
 		{
-			name:    "remove codeblock and newlines",
-			message: "this `` ` ```message \n has` ``` multiple \n newlines \n probably ` ````",
+			name:     "remove codeblock and newlines",
+			message:  "this `` ` ```message \n has` ``` multiple \n newlines \n probably ` ````",
+			expected: "this `` ` message  |  has`  multiple  |  newlines  |  probably ` `",
+		},
+		{
+			name:     "exta leading whitespace",
+			message:  "   message1",
+			expected: "message1",
+		},
+		{
+			name:     "header markdown",
+			message:  "### message1",
+			expected: "message1",
+		},
+		{
+			name:     "extra whitespace and header markdown",
+			message:  "  ### message1",
+			expected: "message1",
+		},
+		{
+			name:     "cleanup everything",
+			message:  "  # this `` ` ```message \n has` ``` multiple \n newlines \n probably ` ````",
+			expected: "this `` ` message  |  has`  multiple  |  newlines  |  probably ` `",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cleanedMessage := cleanMessage(tt.message)
+			assert.Equal(t, tt.expected, cleanedMessage)
 			assert.NotContains(t, cleanedMessage, "```")
 			assert.NotContains(t, cleanedMessage, "\n")
 		})

--- a/server/utils.go
+++ b/server/utils.go
@@ -29,7 +29,15 @@ func cleanAndTrimMessage(message string, trimLength int) string {
 }
 
 func cleanMessage(message string) string {
+	// Remove any leading whitespace and header markdown.
+	message = strings.TrimLeft(message, " ")
+	message = strings.TrimLeft(message, "#")
+	message = strings.TrimLeft(message, " ")
+
+	// Remove all code block markdown.
 	message = strings.Replace(message, "```", "", -1)
+
+	// Replace all newlines to keep summary condensed.
 	message = strings.Replace(message, "\n", " | ", -1)
 
 	return message


### PR DESCRIPTION
Quoted messages in the move-thread summaries would retain header
markdown sizing of the quoted message if that markdown type was
used. This change cleans this type of markdown from the quoted
message so that the summary has standard text sizing.

Fixes https://github.com/gabrieljackson/mattermost-plugin-wrangler/issues/115 

#### Release Note
```release-note
Clean header markdown from move summary messages
```
