### PR TITLE
Add `merge thread` command

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -92,6 +92,13 @@
                 "default": false
             },
             {
+                "key": "MergeThreadEnable",
+                "display_name": "Enable Merging Threads [BETA]",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to merge message threads. Depending on other plugin settings these threads can be merged across channels and teams. Note that message timestamps are preserved when threads are merged which could result in unexpected or confusing message ordering.",
+                "default": false
+            },
+            {
                 "key": "ThreadAttachMessage",
                 "display_name": "Info-Message: Attached a Message",
                 "type": "text",

--- a/server/command_merge_thead_test.go
+++ b/server/command_merge_thead_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeThreadCommand(t *testing.T) {
+	team1 := &model.Team{
+		Id:   model.NewId(),
+		Name: "team-1",
+	}
+	originalChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "original-channel",
+		Type:   model.CHANNEL_OPEN,
+	}
+	privateChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "private-channel",
+		Type:   model.CHANNEL_PRIVATE,
+	}
+	directChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "direct-channel",
+		Type:   model.CHANNEL_DIRECT,
+	}
+	groupChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "group-channel",
+		Type:   model.CHANNEL_GROUP,
+	}
+
+	targetTeam := &model.Team{
+		Id:   model.NewId(),
+		Name: "target-team",
+	}
+	targetChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: targetTeam.Id,
+		Name:   "target-channel",
+	}
+
+	reactions := []*model.Reaction{
+		{
+			UserId: model.NewId(),
+			PostId: model.NewId(),
+		},
+	}
+
+	executor := &model.User{
+		Nickname: "executing user",
+	}
+
+	config := &model.Config{
+		ServiceSettings: model.ServiceSettings{
+			SiteURL: NewString("test.sampledomain.com"),
+		},
+	}
+
+	generatedTargetPosts := mockGeneratePostList(3, targetChannel.Id, false)
+	generatedOriginalPosts := mockGeneratePostList(3, originalChannel.Id, false)
+	generatedPrivatePosts := mockGeneratePostList(3, privateChannel.Id, false)
+	generatedDirectPosts := mockGeneratePostList(3, directChannel.Id, false)
+	generatedGroupPosts := mockGeneratePostList(3, groupChannel.Id, false)
+	oldGeneratedPosts := mockGeneratePostList(3, targetChannel.Id, false)
+	for k := range oldGeneratedPosts.Posts {
+		oldGeneratedPosts.Posts[k].CreateAt = 10
+	}
+
+	targetPostID := generatedTargetPosts.ToSlice()[0].Id
+	originalPostID := generatedOriginalPosts.ToSlice()[0].Id
+	privatePostID := generatedPrivatePosts.ToSlice()[0].Id
+	directPostID := generatedDirectPosts.ToSlice()[0].Id
+	groupPostID := generatedGroupPosts.ToSlice()[0].Id
+	oldPostID := oldGeneratedPosts.ToSlice()[0].Id
+
+	api := &plugintest.API{}
+
+	api.On("GetChannel", originalChannel.Id).Return(originalChannel, nil)
+	api.On("GetChannel", privateChannel.Id).Return(privateChannel, nil)
+	api.On("GetChannel", directChannel.Id).Return(directChannel, nil)
+	api.On("GetChannel", groupChannel.Id).Return(groupChannel, nil)
+	api.On("GetChannel", targetChannel.Id).Return(targetChannel, nil)
+	api.On("GetChannel", oldPostID).Return(targetChannel, nil)
+
+	api.On("GetPostThread", originalPostID, mock.Anything, mock.Anything).Return(generatedOriginalPosts, nil)
+	api.On("GetPostThread", privatePostID, mock.Anything, mock.Anything).Return(generatedPrivatePosts, nil)
+	api.On("GetPostThread", directPostID, mock.Anything, mock.Anything).Return(generatedDirectPosts, nil)
+	api.On("GetPostThread", groupPostID, mock.Anything, mock.Anything).Return(generatedGroupPosts, nil)
+	api.On("GetPostThread", targetPostID, mock.Anything, mock.Anything).Return(generatedTargetPosts, nil)
+	api.On("GetPostThread", oldPostID, mock.Anything, mock.Anything).Return(oldGeneratedPosts, nil)
+
+	api.On("GetChannelMember", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(mockGenerateChannelMember(), nil)
+	api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(directChannel, nil)
+	api.On("GetTeam", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(targetTeam, nil)
+	api.On("GetUser", mock.Anything).Return(executor, nil)
+	api.On("CreatePost", mock.Anything, mock.Anything).Return(mockGeneratePost(), nil)
+	api.On("DeletePost", mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return(nil)
+	api.On("GetReactions", mock.AnythingOfType("string")).Return(reactions, nil)
+	api.On("AddReaction", mock.Anything).Return(nil, nil)
+	api.On("GetConfig", mock.Anything).Return(config)
+	api.On("LogInfo",
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+		mock.AnythingOfTypeArgument("string"),
+	).Return(nil)
+
+	var plugin Plugin
+	plugin.SetAPI(api)
+
+	t.Run("not enabled", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID, targetPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Merge thread command is not enabled")
+	})
+
+	plugin.setConfiguration(&configuration{MergeThreadEnable: true})
+	require.NoError(t, plugin.configuration.IsValid())
+
+	t.Run("no args", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: missing arguments")
+	})
+
+	t.Run("one arg", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: missing arguments")
+	})
+
+	t.Run("private channel", func(t *testing.T) {
+		t.Run("disabled", func(t *testing.T) {
+			resp, isUserError, err := plugin.runMergeThreadCommand([]string{privatePostID, targetPostID}, &model.CommandArgs{ChannelId: privateChannel.Id})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Wrangler is currently configured to not allow moving posts from private channels")
+		})
+	})
+
+	t.Run("direct channel", func(t *testing.T) {
+		t.Run("disabled", func(t *testing.T) {
+			resp, isUserError, err := plugin.runMergeThreadCommand([]string{directPostID, targetPostID}, &model.CommandArgs{ChannelId: directChannel.Id})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Wrangler is currently configured to not allow moving posts from direct message channels")
+		})
+	})
+
+	t.Run("group channel", func(t *testing.T) {
+		t.Run("disabled", func(t *testing.T) {
+			resp, isUserError, err := plugin.runMergeThreadCommand([]string{groupPostID, targetPostID}, &model.CommandArgs{ChannelId: groupChannel.Id})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Wrangler is currently configured to not allow moving posts from group message channels")
+		})
+	})
+
+	t.Run("to another team", func(t *testing.T) {
+		t.Run("disabled", func(t *testing.T) {
+			resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID, targetPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+			require.NoError(t, err)
+			assert.False(t, isUserError)
+			assert.Contains(t, resp.Text, "Wrangler is currently configured to not allow moving messages to different teams")
+		})
+	})
+
+	plugin.configuration.MoveThreadToAnotherTeamEnable = true
+	require.NoError(t, plugin.configuration.IsValid())
+
+	t.Run("merge thead into itself", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID, originalPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: Original and target threads are the same")
+	})
+
+	t.Run("merge older thread into newer thread", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{oldPostID, targetPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: Cannot merge older threads into newer threads. The destination thread must be older than the thread being moved.")
+	})
+
+	t.Run("merge thread successfully", func(t *testing.T) {
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID, targetPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.False(t, isUserError)
+		assert.Contains(t, resp.Text, "A thread with 3 message(s) has been merged")
+	})
+
+	t.Run("thread is above configuration move-maximum", func(t *testing.T) {
+		plugin.configuration.MoveThreadMaxCount = "1"
+		require.NoError(t, plugin.configuration.IsValid())
+
+		resp, isUserError, err := plugin.runMergeThreadCommand([]string{originalPostID, targetPostID}, &model.CommandArgs{ChannelId: model.NewId()})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: the thread is 3 posts long, but this command is configured to only move threads of up to 1 posts")
+	})
+}

--- a/server/command_merge_thread.go
+++ b/server/command_merge_thread.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
+)
+
+const mergeThreadUsage = `
+/wrangler merge thread [ROOT_MESSAGE_ID] [TARGET_ROOT_MESSAGE_ID]
+  Merge the messages of two threads
+    - Message creation timestamps of both threads will be preserved. This could result in merged threads having messages that seem out of order or with different contexts.
+	- Use the '/wrangler list' commands to get message and channel IDs
+`
+
+func getMergeThreadMessage() string {
+	return codeBlock(fmt.Sprintf("`Error: missing arguments\n\n%s", mergeThreadUsage))
+}
+
+func (p *Plugin) runMergeThreadCommand(args []string, extra *model.CommandArgs) (*model.CommandResponse, bool, error) {
+	if !p.getConfiguration().MergeThreadEnable {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Merge thread command is not enabled"), true, nil
+	}
+	if len(args) < 2 {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getMergeThreadMessage()), true, nil
+	}
+	originalPostID := args[0]
+	mergeToPostID := args[1]
+
+	postListResponse, appErr := p.API.GetPostThread(originalPostID)
+	if appErr != nil {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: unable to get post with ID %s; ensure this is correct", originalPostID)), true, nil
+	}
+	wpl := buildWranglerPostList(postListResponse)
+
+	originalChannel, appErr := p.API.GetChannel(wpl.RootPost().ChannelId)
+	if appErr != nil {
+		return nil, false, errors.Errorf("unable to get channel with ID %s", extra.ChannelId)
+	}
+
+	targetPostListResponse, appErr := p.API.GetPostThread(mergeToPostID)
+	if appErr != nil {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: unable to get post with ID %s; ensure this is correct", mergeToPostID)), true, nil
+	}
+	targetRootPost := getRootPostFromPostList(targetPostListResponse)
+
+	_, appErr = p.API.GetChannelMember(targetRootPost.ChannelId, extra.UserId)
+	if appErr != nil {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: channel with ID %s doesn't exist or you are not a member", targetRootPost.ChannelId)), true, nil
+	}
+
+	targetChannel, appErr := p.API.GetChannel(targetRootPost.ChannelId)
+	if appErr != nil {
+		return nil, false, errors.Errorf("unable to get channel with ID %s", targetRootPost.ChannelId)
+	}
+
+	response, userErr, err := p.validateMerge(wpl, targetRootPost, originalChannel, targetChannel, extra)
+	if response != nil || err != nil {
+		return response, userErr, err
+	}
+
+	targetTeam, appErr := p.API.GetTeam(targetChannel.TeamId)
+	if appErr != nil {
+		return nil, false, errors.Errorf("unable to get team with ID %s", targetChannel.TeamId)
+	}
+
+	// Begin merging the thread.
+	p.API.LogInfo("Wrangler is merging a thread",
+		"user_id", extra.UserId,
+		"original_post_id", wpl.RootPost().Id,
+		"original_channel_id", originalChannel.Id,
+		"target_root_post_id", targetRootPost.Id,
+		"target_root_post_channel_id", targetRootPost.ChannelId,
+	)
+
+	// To merge threads, we first copy the original messages(s) to the new
+	// thread and later delete the original messages(s).
+	err = p.mergeWranglerPostlist(wpl, targetRootPost)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Cleanup is handled by simply deleting the root post. Any comments/replies
+	// are automatically marked as deleted for us.
+	appErr = p.API.DeletePost(wpl.RootPost().Id)
+	if appErr != nil {
+		return nil, false, errors.Wrap(appErr, "unable to delete post")
+	}
+
+	p.API.LogInfo("Wrangler thread merge complete",
+		"user_id", extra.UserId,
+		"target_root_post_id", targetRootPost.Id,
+		"target_root_post_channel_id", targetRootPost.ChannelId,
+	)
+
+	newPostLink := makePostLink(*p.API.GetConfig().ServiceSettings.SiteURL, targetTeam.Name, targetRootPost.Id)
+
+	return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("A thread with %d message(s) has been merged: %s\n", wpl.NumPosts(), newPostLink)), false, nil
+}
+
+func (p *Plugin) mergeWranglerPostlist(wpl *WranglerPostList, targetRootPost *model.Post) error {
+	var err error
+	var appErr *model.AppError
+
+	if wpl.ContainsFileAttachments() {
+		// The thread contains at least one attachment. To properly move the
+		// thread, the files will have to be re-uploaded. This is completed
+		// before any messages are moved.
+		// TODO: check number of files that need to be re-uploaded or file size?
+		p.API.LogInfo("Wrangler is re-uploading file attachments",
+			"file_count", wpl.FileAttachmentCount,
+		)
+
+		for _, post := range wpl.Posts {
+			var newFileIDs []string
+			var fileBytes []byte
+			var oldFileInfo, newFileInfo *model.FileInfo
+			for _, fileID := range post.FileIds {
+				oldFileInfo, appErr = p.API.GetFileInfo(fileID)
+				if appErr != nil {
+					return errors.Wrap(appErr, "unable to lookup file info to re-upload")
+				}
+				fileBytes, appErr = p.API.GetFile(fileID)
+				if appErr != nil {
+					return errors.Wrap(appErr, "unable to get file bytes to re-upload")
+				}
+				newFileInfo, appErr = p.API.UploadFile(fileBytes, targetRootPost.ChannelId, oldFileInfo.Name)
+				if appErr != nil {
+					return errors.Wrap(appErr, "unable to re-upload file")
+				}
+
+				newFileIDs = append(newFileIDs, newFileInfo.Id)
+			}
+
+			post.FileIds = newFileIDs
+		}
+	}
+
+	for _, post := range wpl.Posts {
+		var reactions []*model.Reaction
+
+		// Store reactions to be reapplied later.
+		reactions, appErr = p.API.GetReactions(post.Id)
+		if appErr != nil {
+			// Reaction-based errors are logged, but do not cause the plugin to
+			// abort the move thread process.
+			p.API.LogError("Failed to get reactions on original post", "err", appErr)
+		}
+
+		newPost := post.Clone()
+		cleanPostID(newPost)
+		newPost.RootId = targetRootPost.Id
+		newPost.ParentId = targetRootPost.Id
+		newPost.ChannelId = targetRootPost.ChannelId
+
+		newPost, err = p.createPostWithRetries(newPost, 200*time.Millisecond, 3)
+		if err != nil {
+			return errors.Wrap(err, "unable to create new post")
+		}
+
+		for _, reaction := range reactions {
+			reaction.PostId = newPost.Id
+			_, appErr = p.API.AddReaction(reaction)
+			if appErr != nil {
+				// Reaction-based errors are logged, but do not cause the plugin to
+				// abort the move thread process.
+				p.API.LogError("Failed to reapply reactions to post", "err", appErr)
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -41,21 +41,21 @@ func TestCommand(t *testing.T) {
 			args := &model.CommandArgs{UserId: user.Id}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, getHelp(), resp.Text)
+			require.Equal(t, plugin.getHelp(), resp.Text)
 		})
 
 		t.Run("one arg", func(t *testing.T) {
 			args := &model.CommandArgs{UserId: user.Id, Command: "one"}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, getHelp(), resp.Text)
+			require.Equal(t, plugin.getHelp(), resp.Text)
 		})
 
 		t.Run("two args, invalid command", func(t *testing.T) {
 			args := &model.CommandArgs{UserId: user.Id, Command: "one two"}
 			resp, appErr := plugin.ExecuteCommand(context, args)
 			require.Nil(t, appErr)
-			require.Equal(t, getHelp(), resp.Text)
+			require.Equal(t, plugin.getHelp(), resp.Text)
 		})
 
 		t.Run("move command", func(t *testing.T) {
@@ -63,14 +63,14 @@ func TestCommand(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler move"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler move invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 		})
 
@@ -79,14 +79,14 @@ func TestCommand(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler copy"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler copy invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 		})
 
@@ -95,14 +95,30 @@ func TestCommand(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler attach"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler attach invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
+			})
+		})
+
+		t.Run("merge command", func(t *testing.T) {
+			t.Run("missing extra args", func(t *testing.T) {
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler merge"}
+				resp, appErr := plugin.ExecuteCommand(context, args)
+				require.Nil(t, appErr)
+				require.Equal(t, plugin.getHelp(), resp.Text)
+			})
+
+			t.Run("invalid extra args", func(t *testing.T) {
+				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler merge invalid"}
+				resp, appErr := plugin.ExecuteCommand(context, args)
+				require.Nil(t, appErr)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 		})
 
@@ -111,14 +127,14 @@ func TestCommand(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler list"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 
 			t.Run("invalid extra args", func(t *testing.T) {
 				args := &model.CommandArgs{UserId: user.Id, Command: "wrangler list invalid"}
 				resp, appErr := plugin.ExecuteCommand(context, args)
 				require.Nil(t, appErr)
-				require.Equal(t, getHelp(), resp.Text)
+				require.Equal(t, plugin.getHelp(), resp.Text)
 			})
 		})
 	})

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -39,6 +39,7 @@ type configuration struct {
 	MoveThreadFromPrivateChannelEnable       bool
 	MoveThreadFromDirectMessageChannelEnable bool
 	MoveThreadFromGroupMessageChannelEnable  bool
+	MergeThreadEnable                        bool
 
 	ThreadAttachMessage string
 	MoveThreadMessage   string
@@ -155,5 +156,8 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
-	return p.API.RegisterCommand(getCommand(configuration.CommandAutoCompleteEnable))
+	return p.API.RegisterCommand(getCommand(
+		configuration.CommandAutoCompleteEnable,
+		configuration.MergeThreadEnable,
+	))
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -121,6 +121,14 @@ const manifestStr = `
         "default": false
       },
       {
+        "key": "MergeThreadEnable",
+        "display_name": "Enable Merging Threads [BETA]",
+        "type": "bool",
+        "help_text": "Control whether Wrangler is permitted to merge message threads. Depending on other plugin settings these threads can be merged across channels and teams. Note that message timestamps are preserved when threads are merged which could result in unexpected or confusing message ordering.",
+        "placeholder": "",
+        "default": false
+      },
+      {
         "key": "ThreadAttachMessage",
         "display_name": "Info-Message: Attached a Message",
         "type": "text",

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -56,7 +56,10 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.BotUserID = botID
 
-	err = p.API.RegisterCommand(getCommand(config.CommandAutoCompleteEnable))
+	err = p.API.RegisterCommand(getCommand(
+		config.CommandAutoCompleteEnable,
+		config.MergeThreadEnable,
+	))
 	if err != nil {
 		return errors.Wrap(err, "failed to register wrangler command")
 	}


### PR DESCRIPTION
This new optional command allows for merging the messages of thread into another existing thread. The message timestamps are preserved so the resulting thread will contain all messages from both threads in the order in which they were originally created.

Due to how this command functions, it is turned off by default and must be enabled in the plugin configuration before it can be used. The existing plugin permissions for moving threads also apply to merging threads if the command is enabled.

