### PR TITLE
Add merge thread webapp functionality

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -57,16 +57,19 @@ func (p *Plugin) handleRouteAPISettings(w http.ResponseWriter, r *http.Request) 
 		return respondErr(w, http.StatusUnauthorized, errors.New("not authorized"))
 	}
 
-	var enabled bool
+	var webEnabled, mergeThreadEnabled bool
 	if p.getConfiguration().EnableWebUI && p.authorizedPluginUser(mattermostUserID) {
-		enabled = true
+		webEnabled = true
+		mergeThreadEnabled = p.getConfiguration().MergeThreadEnable
 	}
 
 	return respondJSON(w,
 		struct {
-			EnableWebUI bool `json:"enable_web_ui"`
+			EnableWebUI       bool `json:"enable_web_ui"`
+			EnableMergeThread bool `json:"enable_merge_thread"`
 		}{
-			EnableWebUI: enabled,
+			EnableWebUI:       webEnabled,
+			EnableMergeThread: mergeThreadEnabled,
 		},
 	)
 }

--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -5,6 +5,7 @@ import {Channel} from 'mattermost-redux/types/channels';
 import {RECEIVED_PLUGIN_SETTINGS} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL} from '../types/ui';
 import {INITIALIZE_ATTACH_POST, FINALIZE_ATTACH_POST, RichPost} from '../types/attach';
+import {INITIALIZE_MERGE_THREAD, FINALIZE_MERGE_THREAD} from '../types/merge';
 
 import Client from '../client';
 import {INITIALIZE_COPY_TO_CHANNEL, FINALIZE_COPY_TO_CHANNEL} from 'src/types/channel';
@@ -86,6 +87,27 @@ export function finishCopyToChannel(): ActionFunc {
     };
 }
 
+export function startMergingThread(post: RichPost): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
+        dispatch({
+            type: INITIALIZE_MERGE_THREAD,
+            post,
+        });
+
+        return {data: null};
+    };
+}
+
+export function finishMergingThread(): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
+        dispatch({
+            type: FINALIZE_MERGE_THREAD,
+        });
+
+        return {data: null};
+    };
+}
+
 export function getSettings(): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         const {data: settings, error} = await Client.getSettings();
@@ -123,6 +145,15 @@ export function copyThread(postID: string, channelID: string): ActionFunc {
 export function attachMessage(postToBeAttachedID: string, postToAttachToID: string): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const command = `/wrangler attach message ${postToBeAttachedID} ${postToAttachToID}`;
+        await Client.clientExecuteCommand(getState, command);
+
+        return {data: null};
+    };
+}
+
+export function mergeThread(postToBeMergedID: string, postToMergeToID: string): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const command = `/wrangler merge thread ${postToBeMergedID} ${postToMergeToID}`;
         await Client.clientExecuteCommand(getState, command);
 
         return {data: null};

--- a/webapp/src/components/left_sidebar_attach_message/left_sidebar_attach_message.tsx
+++ b/webapp/src/components/left_sidebar_attach_message/left_sidebar_attach_message.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {RichPost} from 'src/types/attach';
+import {RichPost} from 'src/types/post';
 
 import LeftSidebarElement from '../left_sidebar_element';
 

--- a/webapp/src/components/left_sidebar_merge_thread/index.ts
+++ b/webapp/src/components/left_sidebar_merge_thread/index.ts
@@ -1,0 +1,23 @@
+import {connect} from 'react-redux';
+import {Dispatch, Action, bindActionCreators} from 'redux';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+
+import {finishMergingThread} from '../../actions';
+import {getMergeThreadPost} from '../../selectors';
+
+import LeftMergeThreadMessage from './left_sidebar_merge_thread';
+
+function mapStateToProps(state: GlobalState) {
+    return {
+        mergeThreadPost: getMergeThreadPost(state),
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+    return bindActionCreators({
+        finishMergingThread,
+    }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LeftMergeThreadMessage);

--- a/webapp/src/components/left_sidebar_merge_thread/left_sidebar_merge_thread.tsx
+++ b/webapp/src/components/left_sidebar_merge_thread/left_sidebar_merge_thread.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import {RichPost} from 'src/types/post';
+
+import LeftSidebarElement from '../left_sidebar_element';
+
+interface Props {
+    finishMergingThread: Function;
+    mergeThreadPost: RichPost;
+}
+
+type State = {}
+
+export default class LeftMergeThreadMessage extends React.PureComponent<Props, State> {
+    private exit = async (event: React.MouseEvent) => {
+        if (event && event.preventDefault) {
+            event.preventDefault();
+        }
+
+        this.props.finishMergingThread();
+    };
+
+    public render() {
+        const mergeThreadPost = this.props.mergeThreadPost;
+        if (!mergeThreadPost) {
+            return null;
+        }
+
+        const name = mergeThreadPost.user.first_name ? mergeThreadPost.user.first_name : mergeThreadPost.user.username;
+        const originalMessage = mergeThreadPost.post.message;
+        const trimmed = originalMessage.length > length ? originalMessage.substring(0, 75) + '...' : originalMessage;
+        const tooltipContent = (<div>
+            <p>{'Howdy Partner!'}</p>
+            <p>{'It looks like you are merging a thread.'}</p>
+            <p>{'Use the post dropdown on the thread you want to merge into or click the "X" right here to quit.'}</p>
+            <hr/>
+            <p>{name + '\'s message in ' + mergeThreadPost.channel.display_name + ':'}</p>
+            <p>{'"' + trimmed + '"'}</p>
+        </div>);
+
+        return (
+            <LeftSidebarElement
+                id={'merge-thread'}
+                text={'Merging Thread'}
+                tooltip={tooltipContent}
+                clickHandler={this.exit}
+            />
+        );
+    }
+}

--- a/webapp/src/components/merge_thread_dropdown/index.ts
+++ b/webapp/src/components/merge_thread_dropdown/index.ts
@@ -1,0 +1,57 @@
+import {connect} from 'react-redux';
+import {Dispatch, Action, bindActionCreators} from 'redux';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {isCombinedUserActivityPost} from 'mattermost-redux/utils/post_list';
+import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+
+import {startMergingThread, finishMergingThread, mergeThread} from '../../actions';
+import {getMergeThreadPost} from '../../selectors';
+
+import MergeThreadDropdown from './merge_thread_dropdown';
+
+interface Props {
+    postId: string;
+}
+
+function mapStateToProps(state: GlobalState, props: Props) {
+    const post = getPost(state, props.postId);
+    const oldSystemMessageOrNull = post ? isSystemMessage(post) : true;
+    const systemMessage = isCombinedUserActivityPost(post) || oldSystemMessageOrNull;
+
+    let user = null;
+    let channel = null;
+    if (!systemMessage) {
+        user = getUser(state, post.user_id);
+        channel = getChannel(state, post.channel_id);
+    }
+
+    let validMerge = false;
+    if (post) {
+        if (state.entities.posts.postsInThread[post.id] && post.root_id === '') {
+            validMerge = true;
+        }
+    }
+
+    return {
+        post,
+        user,
+        channel,
+        isSystemMessage: systemMessage,
+        isValidMergeMessage: validMerge,
+        mergeThreadPost: getMergeThreadPost(state),
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+    return bindActionCreators({
+        startMergingThread,
+        finishMergingThread,
+        mergeThread,
+    }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MergeThreadDropdown);

--- a/webapp/src/components/merge_thread_dropdown/merge_thread_dropdown.tsx
+++ b/webapp/src/components/merge_thread_dropdown/merge_thread_dropdown.tsx
@@ -13,62 +13,56 @@ interface Props {
     post: Post;
     user: UserProfile;
     channel: Channel
-    postToBeAttached: RichPost;
+    mergeThreadPost: RichPost;
     isSystemMessage: boolean;
-    isValidAttachMessage: boolean;
-    startAttachingPost: Function;
-    finishAttachingPost: Function;
-    attachMessage: Function;
+    isValidMergeMessage: boolean;
+    startMergingThread: Function;
+    finishMergingThread: Function;
+    mergeThread: Function;
 }
 
 type State = {}
 
-export default class AttachMessageDropdown extends React.PureComponent<Props, State> {
-    private handleStartAttaching = async (event: React.MouseEvent) => {
+export default class MergeThreadDropdown extends React.PureComponent<Props, State> {
+    private handleStartMergingThread = async (event: React.MouseEvent) => {
         if (event && event.preventDefault) {
             event.preventDefault();
         }
-        const postToBeAttached = {
+        const mergeThreadPost = {
             post: this.props.post,
             user: this.props.user,
             channel: this.props.channel,
         };
-        this.props.startAttachingPost(postToBeAttached);
+        this.props.startMergingThread(mergeThreadPost);
     };
 
-    private handleAttachMessage = async (event: React.MouseEvent) => {
+    private handleMergeThread = async (event: React.MouseEvent) => {
         if (event && event.preventDefault) {
             event.preventDefault();
         }
 
-        this.props.attachMessage(this.props.postToBeAttached.post.id, this.props.post.id);
-        this.props.finishAttachingPost();
+        this.props.mergeThread(this.props.mergeThreadPost.post.id, this.props.post.id);
+        this.props.finishMergingThread();
     };
 
     public render() {
         if (this.props.isSystemMessage) {
             return null;
         }
-        if (!this.props.isValidAttachMessage && !this.props.postToBeAttached) {
+        if (!this.props.isValidMergeMessage && !this.props.mergeThreadPost) {
             return null;
         }
-        if (this.props.postToBeAttached) {
-            if (this.props.post.id === this.props.postToBeAttached.post.id) {
-                return null;
-            }
-            if (this.props.channel.id !== this.props.postToBeAttached.channel.id) {
-                return null;
-            }
-            if (this.props.post.create_at > this.props.postToBeAttached.post.create_at) {
+        if (this.props.mergeThreadPost) {
+            if (this.props.post.id === this.props.mergeThreadPost.post.id) {
                 return null;
             }
         }
 
-        let dropdownText = 'Attach to Thread';
-        let clickHandler = this.handleStartAttaching;
-        if (this.props.postToBeAttached) {
-            dropdownText = 'Attach to this Thread';
-            clickHandler = this.handleAttachMessage;
+        let dropdownText = 'Merge to thread';
+        let clickHandler = this.handleStartMergingThread;
+        if (this.props.mergeThreadPost) {
+            dropdownText = 'Merge to this Thread';
+            clickHandler = this.handleMergeThread;
         }
 
         return (

--- a/webapp/src/manifest.ts
+++ b/webapp/src/manifest.ts
@@ -111,6 +111,14 @@ const manifest = JSON.parse(`
                 "default": false
             },
             {
+                "key": "MergeThreadEnable",
+                "display_name": "Enable Merging Threads [BETA]",
+                "type": "bool",
+                "help_text": "Control whether Wrangler is permitted to merge message threads. Depending on other plugin settings these threads can be merged across channels and teams. Note that message timestamps are preserved when threads are merged which could result in unexpected or confusing message ordering.",
+                "placeholder": "",
+                "default": false
+            },
+            {
                 "key": "ThreadAttachMessage",
                 "display_name": "Info-Message: Attached a Message",
                 "type": "text",

--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -13,8 +13,10 @@ import MoveThreadModal from './components/move_thread_modal';
 import MoveThreadDropdown from './components/move_thread_dropdown';
 import AttachMessageDropdown from './components/attach_message_dropdown';
 import CopyToChannelDropdown from './components/copy_to_channel_dropdown';
+import MergeThreadDropdown from './components/merge_thread_dropdown';
 import LeftSidebarAttachMessage from './components/left_sidebar_attach_message';
 import LeftSidebarCopyToChannel from './components/left_sidebar_copy_to_channel';
+import LeftSidebarMergeThread from './components/left_sidebar_merge_thread';
 
 const setupUILater = (registry: PluginRegistry, store: Store<object, Action<object>>): () => Promise<void> => async () => {
     registry.registerReducer(reducer);
@@ -32,6 +34,10 @@ const setupUILater = (registry: PluginRegistry, store: Store<object, Action<obje
             'Copy Messages to Channel',
             (channelId: string) => store.dispatch(startCopyToChannel(getChannel(store.getState(), channelId))),
         );
+        if (settings.data.enable_merge_thread) {
+            registry.registerLeftSidebarHeaderComponent(LeftSidebarMergeThread);
+            registry.registerPostDropdownMenuComponent(MergeThreadDropdown);
+        }
     }
 };
 

--- a/webapp/src/reducers/index.ts
+++ b/webapp/src/reducers/index.ts
@@ -3,6 +3,7 @@ import {combineReducers} from 'redux';
 import {RECEIVED_PLUGIN_SETTINGS, ReceivedPluginSettingsAction, Settings} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL, UIActionType, OpenMoveThreadAction} from '../types/ui';
 import {INITIALIZE_ATTACH_POST, FINALIZE_ATTACH_POST, AttachPostInitializeAction} from '../types/attach';
+import {INITIALIZE_MERGE_THREAD, FINALIZE_MERGE_THREAD, MergeTheadInitializeAction} from '../types/merge';
 import {CopyToChannelInitializeAction, FINALIZE_COPY_TO_CHANNEL, INITIALIZE_COPY_TO_CHANNEL} from 'src/types/channel';
 
 function pluginSettings(state: Settings | null = null, action: ReceivedPluginSettingsAction) {
@@ -47,6 +48,17 @@ function postToBeAttached(state = '', action: AttachPostInitializeAction) {
     }
 }
 
+function mergeThreadPost(state = '', action: MergeTheadInitializeAction) {
+    switch (action.type) {
+    case INITIALIZE_MERGE_THREAD:
+        return action.post;
+    case FINALIZE_MERGE_THREAD:
+        return '';
+    default:
+        return state;
+    }
+}
+
 function channelToCopyTo(state = '', action: CopyToChannelInitializeAction) {
     switch (action.type) {
     case INITIALIZE_COPY_TO_CHANNEL:
@@ -62,6 +74,7 @@ const rootReducer = combineReducers({
     pluginSettings,
     getMoveThreadPostID,
     postToBeAttached,
+    mergeThreadPost,
     channelToCopyTo,
     moveThreadModalVisable,
 });

--- a/webapp/src/selectors/index.ts
+++ b/webapp/src/selectors/index.ts
@@ -12,4 +12,6 @@ export const getMoveThreadPostID = (state: GlobalState) => pluginState(state).ge
 
 export const getPostToBeAttached = (state: GlobalState) => pluginState(state).postToBeAttached;
 
+export const getMergeThreadPost = (state: GlobalState) => pluginState(state).mergeThreadPost;
+
 export const getChannelToCopyTo = (state: GlobalState) => pluginState(state).channelToCopyTo;

--- a/webapp/src/types/attach.ts
+++ b/webapp/src/types/attach.ts
@@ -1,14 +1,6 @@
-import {Post} from 'mattermost-redux/types/posts';
-import {UserProfile} from 'mattermost-redux/types/users';
-import {Channel} from 'mattermost-redux/types/channels';
-
 import id from '../plugin_id';
 
-export type RichPost = {
-    post: Post;
-    user: UserProfile;
-    channel: Channel;
-}
+import {RichPost} from './post';
 
 export const INITIALIZE_ATTACH_POST = `${id}_init_attach_post`;
 

--- a/webapp/src/types/merge.ts
+++ b/webapp/src/types/merge.ts
@@ -1,0 +1,18 @@
+import id from '../plugin_id';
+
+import {RichPost} from './post';
+
+export const INITIALIZE_MERGE_THREAD = `${id}_init_merge_thread`;
+
+export type MergeTheadInitializeAction = {
+    type: typeof INITIALIZE_MERGE_THREAD;
+    post: RichPost;
+};
+
+export const FINALIZE_MERGE_THREAD = `${id}_finalize_merge_thread`;
+
+export type MergeTheadFinalizeAction = {
+    type: typeof FINALIZE_MERGE_THREAD;
+};
+
+export type MergeAction = MergeTheadInitializeAction | MergeTheadFinalizeAction;

--- a/webapp/src/types/post.ts
+++ b/webapp/src/types/post.ts
@@ -1,0 +1,9 @@
+import {Post} from 'mattermost-redux/types/posts';
+import {UserProfile} from 'mattermost-redux/types/users';
+import {Channel} from 'mattermost-redux/types/channels';
+
+export type RichPost = {
+    post: Post;
+    user: UserProfile;
+    channel: Channel;
+}

--- a/webapp/src/types/wrangler.ts
+++ b/webapp/src/types/wrangler.ts
@@ -4,6 +4,7 @@ import id from '../plugin_id';
 
 export type Settings = {
     enable_web_ui: boolean;
+    enable_merge_thread: boolean;
 }
 
 export type Channels = Array<Channel>


### PR DESCRIPTION
The webapp now exposes the plugin functionality to merge two threads together. This is provided as an option in the post dropdown menu when thread merging is enabled in the plugin configuration. The experience of merging threads is similar to attaching messages.