### PR TITLE
Simplify Merge Thread UI

### DIFF
--- a/webapp/src/components/left_sidebar_merge_thread/index.ts
+++ b/webapp/src/components/left_sidebar_merge_thread/index.ts
@@ -6,7 +6,7 @@ import {GlobalState} from 'mattermost-redux/types/store';
 import {finishMergingThread} from '../../actions';
 import {getMergeThreadPost} from '../../selectors';
 
-import LeftMergeThreadMessage from './left_sidebar_merge_thread';
+import LeftSidebarMergeThreadMessage from './left_sidebar_merge_thread';
 
 function mapStateToProps(state: GlobalState) {
     return {
@@ -20,4 +20,4 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
     }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(LeftMergeThreadMessage);
+export default connect(mapStateToProps, mapDispatchToProps)(LeftSidebarMergeThreadMessage);

--- a/webapp/src/components/left_sidebar_merge_thread/left_sidebar_merge_thread.tsx
+++ b/webapp/src/components/left_sidebar_merge_thread/left_sidebar_merge_thread.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 type State = {}
 
-export default class LeftMergeThreadMessage extends React.PureComponent<Props, State> {
+export default class LeftSidebarMergeThreadMessage extends React.PureComponent<Props, State> {
     private exit = async (event: React.MouseEvent) => {
         if (event && event.preventDefault) {
             event.preventDefault();
@@ -34,7 +34,7 @@ export default class LeftMergeThreadMessage extends React.PureComponent<Props, S
             <p>{'It looks like you are merging a thread.'}</p>
             <p>{'Use the post dropdown on the thread you want to merge into or click the "X" right here to quit.'}</p>
             <hr/>
-            <p>{name + '\'s message in ' + mergeThreadPost.channel.display_name + ':'}</p>
+            <p>{'A thread started by ' + name + ' in ' + mergeThreadPost.channel.display_name + ':'}</p>
             <p>{'"' + trimmed + '"'}</p>
         </div>);
 

--- a/webapp/src/components/merge_thread_dropdown/index.ts
+++ b/webapp/src/components/merge_thread_dropdown/index.ts
@@ -18,9 +18,15 @@ interface Props {
 }
 
 function mapStateToProps(state: GlobalState, props: Props) {
-    const post = getPost(state, props.postId);
+    let post = getPost(state, props.postId);
     const oldSystemMessageOrNull = post ? isSystemMessage(post) : true;
     const systemMessage = isCombinedUserActivityPost(post) || oldSystemMessageOrNull;
+
+    if (post) {
+        if (post.root_id !== '') {
+            post = getPost(state, post.root_id);
+        }
+    }
 
     let user = null;
     let channel = null;
@@ -29,19 +35,11 @@ function mapStateToProps(state: GlobalState, props: Props) {
         channel = getChannel(state, post.channel_id);
     }
 
-    let validMerge = false;
-    if (post) {
-        if (state.entities.posts.postsInThread[post.id] && post.root_id === '') {
-            validMerge = true;
-        }
-    }
-
     return {
         post,
         user,
         channel,
         isSystemMessage: systemMessage,
-        isValidMergeMessage: validMerge,
         mergeThreadPost: getMergeThreadPost(state),
     };
 }

--- a/webapp/src/components/merge_thread_dropdown/merge_thread_dropdown.tsx
+++ b/webapp/src/components/merge_thread_dropdown/merge_thread_dropdown.tsx
@@ -15,7 +15,6 @@ interface Props {
     channel: Channel
     mergeThreadPost: RichPost;
     isSystemMessage: boolean;
-    isValidMergeMessage: boolean;
     startMergingThread: Function;
     finishMergingThread: Function;
     mergeThread: Function;
@@ -49,11 +48,11 @@ export default class MergeThreadDropdown extends React.PureComponent<Props, Stat
         if (this.props.isSystemMessage) {
             return null;
         }
-        if (!this.props.isValidMergeMessage && !this.props.mergeThreadPost) {
-            return null;
-        }
         if (this.props.mergeThreadPost) {
             if (this.props.post.id === this.props.mergeThreadPost.post.id) {
+                return null;
+            }
+            if (this.props.post.create_at >= this.props.mergeThreadPost.post.create_at) {
                 return null;
             }
         }

--- a/webapp/src/plugin.tsx
+++ b/webapp/src/plugin.tsx
@@ -25,18 +25,22 @@ const setupUILater = (registry: PluginRegistry, store: Store<object, Action<obje
 
     if (settings.data.enable_web_ui) {
         registry.registerRootComponent(MoveThreadModal);
-        registry.registerLeftSidebarHeaderComponent(LeftSidebarAttachMessage);
         registry.registerLeftSidebarHeaderComponent(LeftSidebarCopyToChannel);
         registry.registerPostDropdownMenuComponent(MoveThreadDropdown);
-        registry.registerPostDropdownMenuComponent(AttachMessageDropdown);
         registry.registerPostDropdownMenuComponent(CopyToChannelDropdown);
         registry.registerChannelHeaderMenuAction(
             'Copy Messages to Channel',
             (channelId: string) => store.dispatch(startCopyToChannel(getChannel(store.getState(), channelId))),
         );
+
+        // Merging threads has the same functionality as attaching messages, so
+        // only present one option to users.
         if (settings.data.enable_merge_thread) {
             registry.registerLeftSidebarHeaderComponent(LeftSidebarMergeThread);
             registry.registerPostDropdownMenuComponent(MergeThreadDropdown);
+        } else {
+            registry.registerLeftSidebarHeaderComponent(LeftSidebarAttachMessage);
+            registry.registerPostDropdownMenuComponent(AttachMessageDropdown);
         }
     }
 };


### PR DESCRIPTION
When thread merging is enabled we now hide the option for attaching messages as that functionality is redundant. We also now present the root message information of threads being merged in the LHS as well as hide the option to finalize thread merging on newer threads.