### PR TITLE
Improve AllowedEmailDomain checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Shows version and commit information for the currently-running plugin build.
 The following plugin configuration is available:
 
  - Permitted Wrangler Users: Choose who is allowed to use the Wrangler plugin.
- - Allowed Email Domain: (Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas.
-   - Example: `domain1.com,domain2.net,domain3.org`
+ - Allowed Email Domain: "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas. This also supports full email address matching if you want to limit plugin usage to specific users.
+   - Multiple Domain Example: `domain1.com,domain2.net,domain3.org`
+   - Specific User Email Example: `user1@domain.com,user2@domain.com,user1@otherdomain.com`
  - Enable Wrangler webapp functionality: Enable the work-in-progress Wrangler webapp functionality.
  - Enable Wrangler Command AutoComplete: Control whether command autocomplete is enabled or not. If enabled and Allowed Email Domain is set, then some users will be able to see the Wrangler commands, but will be unable to run them.
  - Max Thread Count Move Size: an optional setting to limit the size of threads that can be moved

--- a/plugin.json
+++ b/plugin.json
@@ -41,7 +41,7 @@
                 "key": "AllowedEmailDomain",
                 "display_name": "Allowed Email Domain",
                 "type": "text",
-                "help_text": "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas."
+                "help_text": "(Optional) When set, users must have an email ending in this domain to use Wrangler. Multiple domains can be specified by separating them with commas. This also supports full email address matching if you want to limit plugin usage to specific users."
             },
             {
                 "key": "EnableWebUI",

--- a/server/command.go
+++ b/server/command.go
@@ -204,8 +204,14 @@ func (p *Plugin) authorizedPluginUser(userID string) bool {
 	if len(config.AllowedEmailDomain) != 0 {
 		emailDomains := strings.Split(config.AllowedEmailDomain, ",")
 		for _, emailDomain := range emailDomains {
-			if strings.HasSuffix(user.Email, emailDomain) {
-				return true
+			if strings.Contains(emailDomain, "@") {
+				if user.Email == emailDomain {
+					return true
+				}
+			} else {
+				if strings.HasSuffix(user.Email, "@"+emailDomain) {
+					return true
+				}
 			}
 		}
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -255,6 +255,20 @@ func TestCommand(t *testing.T) {
 				assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
 			})
 
+			t.Run("enabled, user email domain partial match", func(t *testing.T) {
+				plugin.setConfiguration(&configuration{
+					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+					AllowedEmailDomain:     "domain.com",
+				})
+				args := &model.CommandArgs{
+					UserId:  user.Id,
+					Command: "wrangler info",
+				}
+				resp, appErr := plugin.ExecuteCommand(context, args)
+				require.Nil(t, appErr)
+				assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
+			})
+
 			t.Run("email domain setting is empty", func(t *testing.T) {
 				plugin.setConfiguration(&configuration{
 					PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
@@ -339,6 +353,21 @@ func TestCommand(t *testing.T) {
 					require.NoError(t, err)
 					assert.False(t, userError)
 					assert.Equal(t, infoResp, resp)
+				})
+
+				t.Run("user has email address that has suffix of a full allowed email", func(t *testing.T) {
+					user.Email = "1user1@test.com"
+					plugin.setConfiguration(&configuration{
+						PermittedWranglerUsers: permittedUserSystemAdminsAndEmail,
+						AllowedEmailDomain:     "emaildomain.com,anotherdomain.com,user1@test.com",
+					})
+					args := &model.CommandArgs{
+						UserId:  user.Id,
+						Command: "wrangler info",
+					}
+					resp, appErr := plugin.ExecuteCommand(context, args)
+					require.Nil(t, appErr)
+					assert.Equal(t, "Permission denied. Please talk to your system administrator to get access.", resp.Text)
 				})
 			})
 		})


### PR DESCRIPTION
The plugin configuration `AllowedEmailDomain` previously allowed for defining generic email domains or specific user email addresses which were permitted to use the plugin. This change improves the logic for checking these values to prevent unintended edge cases and better documents how to limit usage to specific email addresses.

