### PR TITLE
Add create post permission check

### DIFF
--- a/server/command_copy_thread_test.go
+++ b/server/command_copy_thread_test.go
@@ -39,6 +39,12 @@ func TestCopyThreadCommand(t *testing.T) {
 		Name:   "group-channel",
 		Type:   model.CHANNEL_GROUP,
 	}
+	readOnlyChannel := &model.Channel{
+		Id:     model.NewId(),
+		TeamId: team1.Id,
+		Name:   "read-only",
+		Type:   model.CHANNEL_OPEN,
+	}
 
 	targetTeam := &model.Team{
 		Id:   model.NewId(),
@@ -75,12 +81,15 @@ func TestCopyThreadCommand(t *testing.T) {
 	api.On("GetChannel", privateChannel.Id).Return(privateChannel, nil)
 	api.On("GetChannel", directChannel.Id).Return(directChannel, nil)
 	api.On("GetChannel", groupChannel.Id).Return(groupChannel, nil)
+	api.On("GetChannel", readOnlyChannel.Id).Return(readOnlyChannel, nil)
 	api.On("GetChannel", mock.AnythingOfType("string")).Return(targetChannel, nil)
 	api.On("GetPostThread", mock.AnythingOfType("string")).Return(generatedPosts, nil)
 	api.On("GetChannelMember", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(mockGenerateChannelMember(), nil)
 	api.On("GetDirectChannel", mock.AnythingOfType("string"), mock.Anything).Return(directChannel, nil)
 	api.On("GetTeam", mock.AnythingOfType("string")).Return(targetTeam, nil)
 	api.On("GetUser", mock.Anything).Return(executor, nil)
+	api.On("HasPermissionToChannel", mock.AnythingOfType("string"), readOnlyChannel.Id, mock.Anything).Return(false)
+	api.On("HasPermissionToChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.Anything).Return(true)
 	api.On("CreatePost", mock.Anything, mock.Anything).Return(mockGeneratePost(), nil)
 	api.On("DeletePost", mock.AnythingOfType("string")).Return(nil)
 	api.On("GetReactions", mock.AnythingOfType("string")).Return(reactions, nil)
@@ -205,6 +214,13 @@ func TestCopyThreadCommand(t *testing.T) {
 
 	targetCall.Return(nil, nil)
 	api.On("GetChannelMember", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(mockGenerateChannelMember(), nil)
+
+	t.Run("no permission to create posts in target channel", func(t *testing.T) {
+		resp, isUserError, err := plugin.runCopyThreadCommand([]string{originalPostID, readOnlyChannel.Id}, &model.CommandArgs{ChannelId: originalChannel.Id})
+		require.NoError(t, err)
+		assert.True(t, isUserError)
+		assert.Contains(t, resp.Text, "Error: you don't have permissions to create posts in channel read-only")
+	})
 
 	t.Run("copy thread successfully", func(t *testing.T) {
 		require.NoError(t, plugin.configuration.IsValid())

--- a/server/message_helpers.go
+++ b/server/message_helpers.go
@@ -18,6 +18,10 @@ func (p *Plugin) validateMoveOrCopy(wpl *WranglerPostList, originalChannel *mode
 		return nil, false, errors.New("The wrangler post list contains no posts")
 	}
 
+	if !p.API.HasPermissionToChannel(extra.UserId, targetChannel.Id, model.PERMISSION_CREATE_POST) {
+		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Error: you don't have permissions to create posts in channel %s", targetChannel.Name)), true, nil
+	}
+
 	config := p.getConfiguration()
 
 	switch originalChannel.Type {


### PR DESCRIPTION
This check is performed when moving or copying posts to a new channel to ensure the user has the ability to create posts in the channel. This avoids issues where the channel is read-only to the user.
