### PR TITLE
Reduce Wrangler modal re-rendering

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -1,6 +1,9 @@
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import {Channel} from 'mattermost-redux/types/channels';
+import {Team} from 'mattermost-redux/types/teams';
+import {getTeam, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
+import {Client4} from 'mattermost-redux/client';
 
 import {RECEIVED_PLUGIN_SETTINGS} from '../types/wrangler';
 import {OPEN_MOVE_THREAD_MODAL, CLOSE_MOVE_THREAD_MODAL} from '../types/ui';
@@ -121,6 +124,35 @@ export function getSettings(): ActionFunc {
         });
 
         return {data: settings};
+    };
+}
+
+export function getMyTeams(): Function {
+    return async (_: DispatchFunc, getState: GetStateFunc) => {
+        const myTeamMemberships = getTeamMemberships(getState());
+        const myTeams = Array<Team>();
+        Object.keys(myTeamMemberships).forEach((id) => {
+            const team = getTeam(getState(), id);
+            myTeams.push(team);
+        });
+
+        return myTeams;
+    };
+}
+
+export function getChannelsForTeam(teamID: string): Function {
+    return async () => {
+        let allMyChannelsInTeam = Array<Channel>();
+        allMyChannelsInTeam = await Client4.getMyChannels(teamID);
+
+        const myOpenAndPrivateChannelsInTeam = Array<Channel>();
+        allMyChannelsInTeam.forEach((channel) => {
+            if (channel.type === 'O' || channel.type === 'P') {
+                myOpenAndPrivateChannelsInTeam.push(channel);
+            }
+        });
+
+        return myOpenAndPrivateChannelsInTeam;
     };
 }
 

--- a/webapp/src/components/move_thread_modal/index.ts
+++ b/webapp/src/components/move_thread_modal/index.ts
@@ -2,14 +2,10 @@ import {connect} from 'react-redux';
 import {Dispatch, Action, bindActionCreators} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
-import {Client4} from 'mattermost-redux/client';
-import {getTeam, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
-import {Team} from 'mattermost-redux/types/teams';
-import {Channel} from 'mattermost-redux/types/channels';
 import {getPost as getPostSel} from 'mattermost-redux/selectors/entities/posts';
 
 import {isMoveModalVisable, getMoveThreadPostID} from '../../selectors';
-import {closeMoveThreadModal, moveThread, copyThread} from '../../actions';
+import {closeMoveThreadModal, moveThread, copyThread, getMyTeams, getChannelsForTeam} from '../../actions';
 
 import MoveThreadModal from './move_thread_modal';
 
@@ -28,35 +24,8 @@ function mapStateToProps(state: GlobalState) {
         message = post.message;
     }
 
-    const getMyTeamsFunc = () => {
-        const myTeamMemberships = getTeamMemberships(state);
-        const myTeams = Array<Team>();
-        Object.keys(myTeamMemberships).forEach((id) => {
-            const team = getTeam(state, id);
-            myTeams.push(team);
-        });
-
-        return myTeams;
-    };
-
-    const getChannelsForTeamFunc = async (teamID: string) => {
-        let allMyChannelsInTeam = Array<Channel>();
-        allMyChannelsInTeam = await Client4.getMyChannels(teamID);
-
-        const myOpenAndPrivateChannelsInTeam = Array<Channel>();
-        allMyChannelsInTeam.forEach((channel) => {
-            if (channel.type === 'O' || channel.type === 'P') {
-                myOpenAndPrivateChannelsInTeam.push(channel);
-            }
-        });
-
-        return myOpenAndPrivateChannelsInTeam;
-    };
-
     return {
         visible: isMoveModalVisable(state),
-        getMyTeams: getMyTeamsFunc,
-        getChannelsForTeam: getChannelsForTeamFunc,
         postID,
         message,
         threadCount,
@@ -66,6 +35,8 @@ function mapStateToProps(state: GlobalState) {
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
     return bindActionCreators({
         closeMoveThreadModal,
+        getMyTeams,
+        getChannelsForTeam,
         moveThread,
         copyThread,
     }, dispatch);

--- a/webapp/src/components/move_thread_modal/move_thread_modal.tsx
+++ b/webapp/src/components/move_thread_modal/move_thread_modal.tsx
@@ -60,7 +60,7 @@ export default class MoveThreadModal extends React.PureComponent<Props, State> {
     }
 
     private loadTeams = async () => {
-        const myTeams = this.props.getMyTeams();
+        const myTeams = await this.props.getMyTeams();
 
         let firstTeamID = '';
         let firstChannelID = '';


### PR DESCRIPTION
This change refactors the functions used in the move/copy thread modal to heavily reduce the amount of rendering that occurs when redux state updates.