### PR TITLE
Check for undefined teams in webapp

### DIFF
--- a/webapp/src/actions/index.ts
+++ b/webapp/src/actions/index.ts
@@ -133,7 +133,15 @@ export function getMyTeams(): Function {
         const myTeams = Array<Team>();
         Object.keys(myTeamMemberships).forEach((id) => {
             const team = getTeam(getState(), id);
-            myTeams.push(team);
+
+            // There are cases where a team may not be loaded into redux even
+            // though they exist. This seems most likely to occur when many
+            // teams exist on the Mattermost instance. This will protect against
+            // crashes, but looking up missing teams will require further
+            // investigation.
+            if (typeof team !== 'undefined') {
+                myTeams.push(team);
+            }
         });
 
         return myTeams;


### PR DESCRIPTION
When building certain webapp components a list of teams the user belongs to is required. When looking up these teams there appears to be certain edge cases where a team object may not be present in redux. It's unclear if this should be happening, but this change checks if the team is undefined to prevent plugin crashes when a team is missing.

