### PR TITLE
Update logic for finding message IDs in links

### DIFF
--- a/server/command_attach_message.go
+++ b/server/command_attach_message.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
 )
@@ -21,8 +22,8 @@ func (p *Plugin) runAttachMessageCommand(args []string, extra *model.CommandArgs
 	if len(args) < 2 {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getAttachMessageCommand()), true, nil
 	}
-	postToBeAttachedID := cleanInputID(args[0])
-	postToAttachToID := cleanInputID(args[1])
+	postToBeAttachedID := cleanInputID(args[0], extra.SiteURL)
+	postToAttachToID := cleanInputID(args[1], extra.SiteURL)
 
 	if postToBeAttachedID == postToAttachToID {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Error: the two provided message IDs should not be the same"), true, nil

--- a/server/command_attach_message_test.go
+++ b/server/command_attach_message_test.go
@@ -77,7 +77,7 @@ func TestAttachMessageCommand(t *testing.T) {
 
 	config := &model.Config{
 		ServiceSettings: model.ServiceSettings{
-			SiteURL: NewString("test.sampledomain.com"),
+			SiteURL: NewString("https://test.sampledomain.com"),
 		},
 	}
 
@@ -207,10 +207,10 @@ func TestAttachMessageCommand(t *testing.T) {
 		plugin.setConfiguration(&configuration{MoveThreadToAnotherTeamEnable: true})
 		require.NoError(t, plugin.configuration.IsValid())
 
-		postToBeAttachedLink := fmt.Sprintf("https://%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, postToBeAttachedByLink.Id)
-		postToAttachToLink := fmt.Sprintf("https://%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, postToAttachToByLink.Id)
-		postToBeAttachedID := getMessageIDFromLink(postToBeAttachedLink)
-		postToAttachToID := getMessageIDFromLink(postToAttachToLink)
+		postToBeAttachedLink := fmt.Sprintf("%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, postToBeAttachedByLink.Id)
+		postToAttachToLink := fmt.Sprintf("%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, postToAttachToByLink.Id)
+		postToBeAttachedID := getMessageIDFromLink(postToBeAttachedLink, *config.ServiceSettings.SiteURL)
+		postToAttachToID := getMessageIDFromLink(postToAttachToLink, *config.ServiceSettings.SiteURL)
 
 		resp, isUserError, err := plugin.runAttachMessageCommand([]string{postToBeAttachedID, postToAttachToID}, &model.CommandArgs{ChannelId: channel1.Id})
 		require.NoError(t, err)

--- a/server/command_copy_thread.go
+++ b/server/command_copy_thread.go
@@ -21,7 +21,7 @@ func (p *Plugin) runCopyThreadCommand(args []string, extra *model.CommandArgs) (
 	if len(args) < 2 {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getCopyThreadMessage()), true, nil
 	}
-	postID := cleanInputID(args[0])
+	postID := cleanInputID(args[0], extra.SiteURL)
 	channelID := args[1]
 
 	postListResponse, appErr := p.API.GetPostThread(postID)

--- a/server/command_copy_thread_test.go
+++ b/server/command_copy_thread_test.go
@@ -241,7 +241,7 @@ func TestCopyThreadCommand(t *testing.T) {
 
 		// Create dummy-links and generate post IDs from them.
 		originalPostLink := fmt.Sprintf("https://%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, originalPostByLinkID)
-		cleanOriginalPostID := getMessageIDFromLink(originalPostLink)
+		cleanOriginalPostID := getMessageIDFromLink(originalPostLink, *config.ServiceSettings.SiteURL)
 
 		resp, isUserError, err := plugin.runCopyThreadCommand([]string{cleanOriginalPostID, targetChannel.Id}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)

--- a/server/command_merge_thead_test.go
+++ b/server/command_merge_thead_test.go
@@ -258,8 +258,8 @@ func TestMergeThreadCommand(t *testing.T) {
 		// Create dummy-links and generate post IDs from them.
 		originalPostLink := fmt.Sprintf("https://%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, originalPostID)
 		targetPostLink := fmt.Sprintf("https://%s/%s/pl/%s", *config.ServiceSettings.SiteURL, team1.Name, targetByLinkPostID)
-		cleanOriginalPostID := getMessageIDFromLink(originalPostLink)
-		cleanTargetPostID := getMessageIDFromLink(targetPostLink)
+		cleanOriginalPostID := getMessageIDFromLink(originalPostLink, *config.ServiceSettings.SiteURL)
+		cleanTargetPostID := getMessageIDFromLink(targetPostLink, *config.ServiceSettings.SiteURL)
 
 		resp, isUserError, err := plugin.runMergeThreadCommand([]string{cleanOriginalPostID, cleanTargetPostID}, &model.CommandArgs{ChannelId: originalChannel.Id})
 		require.NoError(t, err)

--- a/server/command_merge_thread.go
+++ b/server/command_merge_thread.go
@@ -26,8 +26,8 @@ func (p *Plugin) runMergeThreadCommand(args []string, extra *model.CommandArgs) 
 	if len(args) < 2 {
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, getMergeThreadMessage()), true, nil
 	}
-	originalPostID := cleanInputID(args[0])
-	mergeToPostID := cleanInputID(args[1])
+	originalPostID := cleanInputID(args[0], extra.SiteURL)
+	mergeToPostID := cleanInputID(args[1], extra.SiteURL)
 
 	postListResponse, appErr := p.API.GetPostThread(originalPostID)
 	if appErr != nil {

--- a/server/command_move_thread.go
+++ b/server/command_move_thread.go
@@ -57,7 +57,7 @@ func (p *Plugin) runMoveThreadCommand(args []string, extra *model.CommandArgs) (
 	if err != nil {
 		return nil, false, err
 	}
-	postID := cleanInputID(args[0])
+	postID := cleanInputID(args[0], extra.SiteURL)
 	channelID := args[1]
 
 	postListResponse, appErr := p.API.GetPostThread(postID)

--- a/server/utils.go
+++ b/server/utils.go
@@ -106,23 +106,26 @@ func NewInt64(n int64) *int64 { return &n }
 // NewString returns a pointer to a given string.
 func NewString(s string) *string { return &s }
 
-func isInputMessageLink(input string) bool {
-	match, _ := regexp.MatchString("(http|https)://[a-zA-Z0-9\\-_.]+(:\\d+)?/([a-zA-Z0-9\\-_]+)/pl/[a-zA-Z0-9]{26}", input)
-	return match
+var pathRegex = regexp.MustCompile(`/([a-zA-Z0-9\-_]+)/pl/([a-zA-Z0-9]{26})?$`)
+
+// getMessageIDFromLink will return the message ID of a properly formatted
+// message link or the original input value if there is no match.
+func getMessageIDFromLink(input, siteURL string) string {
+	if !strings.HasPrefix(input, siteURL) {
+		return input
+	}
+	path := strings.TrimPrefix(input, siteURL)
+	if !pathRegex.MatchString(path) {
+		return input
+	}
+	matches := pathRegex.FindStringSubmatch(path)
+	if len(matches) < 3 {
+		return input
+	}
+
+	return matches[2]
 }
 
-func getMessageIDFromLink(inputLink string) string {
-	regex := regexp.MustCompile(`(http|https)://[a-zA-Z0-9\-_.]+(:\d+)?/([a-zA-Z0-9\-_]+)/pl/([a-zA-Z0-9]{26})`)
-	matches := regex.FindStringSubmatch(inputLink)
-	if len(matches) >= 5 {
-		return matches[4]
-	}
-	return ""
-}
-
-func cleanInputID(input string) string {
-	if isInputMessageLink(input) {
-		return getMessageIDFromLink(input)
-	}
-	return input
+func cleanInputID(input, siteURL string) string {
+	return getMessageIDFromLink(input, siteURL)
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -73,85 +73,48 @@ func TestMakeBotDM(t *testing.T) {
 	}
 }
 
-func TestIsInputMessageLink(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected bool
-	}{
-		{
-			name:     "valid link",
-			input:    "https://test.sampledomain.com/team_id/pl/8w89igrsffyt3ghmwsmsgyeoqe",
-			expected: true,
-		},
-		{
-			name:     "invalid link",
-			input:    "https://invalid_link",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isInputMessageLink(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetMessageIDFromLink(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "valid link",
-			input:    "https://test.sampledomain.com/team-1/pl/8w89igrsffyt3ghmwsmsgyeoqe",
-			expected: "8w89igrsffyt3ghmwsmsgyeoqe",
-		},
-		{
-			name:     "invalid link",
-			input:    "https://invalid_link",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getMessageIDFromLink(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestCleanInputID(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
+		siteURL  string
 		expected string
 	}{
 		{
 			name:     "valid link",
 			input:    "https://test.sampledomain.com/team2/pl/8w89igrsffyt3ghmwsmsgyeoqe",
+			siteURL:  "https://test.sampledomain.com",
 			expected: "8w89igrsffyt3ghmwsmsgyeoqe",
 		},
 		{
 			name:     "valid id",
 			input:    "8w89igrsffyt3ghmwsmsgyeoqe",
+			siteURL:  "https://test.sampledomain.com",
 			expected: "8w89igrsffyt3ghmwsmsgyeoqe",
 		},
 		{
 			name:     "invalid link",
 			input:    "https://invalid_link",
+			siteURL:  "https://invalid_link",
 			expected: "https://invalid_link",
+		},
+		{
+			name:     "invalid link due to short ID",
+			input:    "https://test.sampledomain.com/team2/pl/tooshort",
+			siteURL:  "https://test.sampledomain.com",
+			expected: "https://test.sampledomain.com/team2/pl/tooshort",
+		},
+		{
+			name:     "invalid link due to long ID",
+			input:    "https://test.sampledomain.com/team2/pl/toolong8w89igrsffyt3ghmwsmsgyeoqe",
+			siteURL:  "https://test.sampledomain.com",
+			expected: "https://test.sampledomain.com/team2/pl/toolong8w89igrsffyt3ghmwsmsgyeoqe",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := cleanInputID(tt.input)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, cleanInputID(tt.input, tt.siteURL))
 		})
 	}
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -87,16 +87,28 @@ func TestCleanInputID(t *testing.T) {
 			expected: "8w89igrsffyt3ghmwsmsgyeoqe",
 		},
 		{
+			name:     "valid link, but for another server",
+			input:    "https://test.sampledomain.com/team2/pl/8w89igrsffyt3ghmwsmsgyeoqe",
+			siteURL:  "https://test2.sampledomain.com",
+			expected: "https://test.sampledomain.com/team2/pl/8w89igrsffyt3ghmwsmsgyeoqe",
+		},
+		{
 			name:     "valid id",
 			input:    "8w89igrsffyt3ghmwsmsgyeoqe",
 			siteURL:  "https://test.sampledomain.com",
 			expected: "8w89igrsffyt3ghmwsmsgyeoqe",
 		},
 		{
-			name:     "invalid link",
+			name:     "invalid link with no path",
 			input:    "https://invalid_link",
 			siteURL:  "https://invalid_link",
 			expected: "https://invalid_link",
+		},
+		{
+			name:     "invalid link with partial path",
+			input:    "https://invalid_linkteam2/pl/",
+			siteURL:  "https://invalid_link",
+			expected: "https://invalid_linkteam2/pl/",
 		},
 		{
 			name:     "invalid link due to short ID",


### PR DESCRIPTION
This new logic simplifies the regex for finding message IDs in links, while also ensuring the links match the Mattermost server SiteURL. This should prevent ID lookup when a link from another Mattermost server is used while also improving performance in most cases.

