### PR TITLE
Remove AI Plugin post prop from moved messages

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
+const aiPluginPostProp = "activate_ai"
+
 func makePostLink(siteURL, teamName, postID string) string {
 	return fmt.Sprintf("%s/%s/pl/%s", siteURL, teamName, postID)
 }
@@ -27,6 +29,11 @@ func cleanPost(post *model.Post) {
 	post.CreateAt = 0
 	post.UpdateAt = 0
 	post.EditAt = 0
+
+	// Remove post props of other plugins where unintended behavior may occur.
+	if post.GetProp(aiPluginPostProp) != nil {
+		post.DelProp(aiPluginPostProp)
+	}
 }
 
 func cleanPostID(post *model.Post) {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -127,6 +128,37 @@ func TestCleanInputID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, cleanInputID(tt.input, tt.siteURL))
+		})
+	}
+}
+
+func TestCleanPost(t *testing.T) {
+	tests := []struct {
+		name     string
+		post     *model.Post
+		expected *model.Post
+	}{
+		{
+			name:     "empty",
+			post:     &model.Post{},
+			expected: &model.Post{},
+		},
+		{
+			name:     "standard clean",
+			post:     &model.Post{Id: "ID1", CreateAt: 1, UpdateAt: 2, EditAt: 3, Message: "test message", Props: model.StringInterface{"testProp": "test"}},
+			expected: &model.Post{Message: "test message", Props: model.StringInterface{"testProp": "test"}},
+		},
+		{
+			name:     "remove ai plugin post prop",
+			post:     &model.Post{Id: "ID1", CreateAt: 1, UpdateAt: 2, EditAt: 3, Message: "test message", Props: model.StringInterface{"testProp": "test", aiPluginPostProp: "true"}},
+			expected: &model.Post{Message: "test message", Props: model.StringInterface{"testProp": "test"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanPost(tt.post)
+			assert.Equal(t, tt.expected, tt.post)
 		})
 	}
 }


### PR DESCRIPTION
This should help prevent unintended behavior when using both Wrangler and AI plugins.